### PR TITLE
deadlock im ringbuffer

### DIFF
--- a/main.c
+++ b/main.c
@@ -156,6 +156,7 @@ void throw_errors()
 	if(RingBufHasError) 
 	{
 		USARTsend_str(" ERROR: Receivebuffer full");
+		RingBufClearError;
 	}
 	if(gERROR.crc_failure)
 	{


### PR DESCRIPTION
Hi nils,
ich hab bei mir lokal den code jetzt soweit, das ich das programm ablaufen lassen kann. spi und usart schrieben einfach in eine datei und die interrupt routine (ISR) ist ein eigener thread der zeichen von der standard eingabe liest.
Jetzt ist mir folgendes aufgefallen: Wenn der Ringbuffer einmal voll ist und und sein error bit setzt, wird dies nie wieder zurück gesetzt! das ist doch so nicht beabsichtigt oder? ich kann mir sehr gut vorstellen, dass dir das einigen ärger bereitet hat. das erklärt vielleicht auch das problem mit den NOPs das du früher mal hattest. Dieser commit hier behebt erstmal nur dieses problem, indem nach der fehler ausgabe wie bei anderen fehler ausgaben das bit resetet wird. alternativ könnte man es auch im RingBufferGet reseten.
