### PR TITLE
Testbranche

### DIFF
--- a/ledstrip.c
+++ b/ledstrip.c
@@ -4,7 +4,6 @@
 
 #include "ledstrip.h"
 
-
 #define INC_BIT_COUNTER(PTR, MASK) \
 	MASK = MASK << 1; \
 	if(0 == MASK) { \
@@ -66,7 +65,7 @@ uns8 GET_BIT_AT(uns8* PTR, uns8 POSITION) {
 		gLedBuf.periodeLength[k] = 0; \
 		gLedBuf.delta[k] = delta; \
 		if((0 != delta)) {\
-			timevalue = 1000 * pCmd->timevalue; \
+			timevalue = 1000 / CYCLE_TMMS * pCmd->timevalue; \
 			gLedBuf.periodeLength[k] = timevalue / delta; \
 		} \
 
@@ -129,7 +128,8 @@ void ledstrip_do_fade(void)
 void ledstrip_set_fade(struct cmd_set_fade *pCmd)
 {
 	uns8 k, stepmask;
-	uns8 delta, timevalue;
+	uns8 delta;
+	uns16 timevalue;
 	uns8 oldColor, newColor;
 	uns8* stepaddress = gLedBuf.step;
 	for(k = 0; k < NUM_OF_LED*3; k++) {
@@ -152,7 +152,7 @@ void ledstrip_set_fade(struct cmd_set_fade *pCmd)
 	);
 }
 
-void ledstripe_update_fade(void)
+void ledstrip_update_fade(void)
 {
 	uns8 i;
 	for(i = 0; i < NUM_OF_LED*3; i++)

--- a/ledstrip.h
+++ b/ledstrip.h
@@ -16,7 +16,7 @@ struct LedBuffer{
 	uns8 delta[NUM_OF_LED*3];			// delta until new fade color arrived, decremented each periode
 	unsigned short cyclesLeft[NUM_OF_LED*3];	// cycles left in current periode
 	unsigned short periodeLength[NUM_OF_LED*3];	// number of cycles in one periode
-	uns8 step[NUM_OF_LED / 8* 3]; // if bit is set led_array is incremented each periode else decremented
+	uns8 step[NUM_OF_LED / 8* 3]; // if bit is set led_array is decremented each periode if not set incremented
 };
 
 extern bank1 struct LedBuffer gLedBuf;

--- a/ledstrip.h
+++ b/ledstrip.h
@@ -16,7 +16,7 @@ struct LedBuffer{
 	uns8 delta[NUM_OF_LED*3];			// delta until new fade color arrived, decremented each periode
 	unsigned short cyclesLeft[NUM_OF_LED*3];	// cycles left in current periode
 	unsigned short periodeLength[NUM_OF_LED*3];	// number of cycles in one periode
-	uns8 step[NUM_OF_LED / 8* 3]; // if bit is set led_array is decremented each periode if not set incremented
+	uns8 step[NUM_OF_LED / 8* 3]; // if bit is set led_array is decremented each periode else incremented
 };
 
 extern bank1 struct LedBuffer gLedBuf;

--- a/main.c
+++ b/main.c
@@ -110,18 +110,14 @@ void main(void)
 	while(1)
 	{
 #ifdef X86
-		usleep(1000);
+		// give opengl thread a chance to run
+		usleep(10);
 #endif
 		Check_INPUT();
 		throw_errors();
 		commandstorage_get_commands();
 		commandstorage_execute_commands();
-
-		if(g_timer_signaled > 0)
-		{
-			ledstripe_update_fade();
-			ledstrip_do_fade();
-		}
+		ledstrip_do_fade();
 	}
 }
 //*********************** UNTERPROGRAMME **********************************************

--- a/platform.h
+++ b/platform.h
@@ -35,20 +35,22 @@
 	#define AllowInterrupts(x)
 	#define InitFactoryRestoreWLAN(x)
 	#define InitFET(x)
+	#define InitInputs(x)	
 	#define OsciInit(x)
 	#define PowerOnLEDs(x) g_led_off = 0;
 	#define PowerOffLEDs(x) g_led_off = 1;
-	#define Check_INPUT(x)
+
+	#define Check_INPUT(x)	
 #else
 	#include "inline.h"
 
 	#define AllowInterrupts(x) RCIE=1;PEIE=1;GIE=1;
 	#define InitFactoryRestoreWLAN(x) TRISA.0 = 0; 
 	#define InitFET(x) TRISC.0 = 0; //Ausgang für FET initalisieren
+	#define InitInputs(x) CLRF(PORTB); CLRF(LATB); CLRF(ANSELB); //Eingänge am PORTB initialisieren
 	#define OsciInit(x) OSCCON = 0b01110010; //OSZILLATOR initialisieren: 4xPLL deactivated;INTOSC 16MHz
 	#define PowerOnLEDs(x) BCF(PORTC.0); //Spannungsversorgung für LED's einschalten
 	#define PowerOffLEDs(x) BSF(PORTC.0); //Spannungsversorgung für LED's ausschalten
-	#define InitInputs(x) CLRF(PORTB); CLRF(LATB); CLRF(ANSELB); //Eingänge am PORTB initialisieren
 	
 	void Check_INPUT();
 #endif

--- a/platform.h
+++ b/platform.h
@@ -5,6 +5,8 @@
 #define TRUE  1
 #define FALSE 0
 
+#define CYCLE_TMMS 10		//cycle time in milliseconds
+
 #ifdef X86
 	typedef char bit;
 	typedef unsigned char uns8;
@@ -33,6 +35,4 @@
 	
 	void Check_INPUT();
 #endif
-
-	extern unsigned short g_timer_signaled;
 #endif /* #ifndef _PLATFORM_H_ */

--- a/x86_wrapper.c
+++ b/x86_wrapper.c
@@ -11,8 +11,8 @@ void* timer_interrupt(void* unused)
 {
 	for(;;)
 	{
-		usleep(1000);
-		g_timer_signaled++;
+		usleep(1000 * CYCLE_TMMS);
+		ledstrip_update_fade();
 	}
 }
 


### PR DESCRIPTION
Bugfix damit der timer richtig funktioniert, wenn man dem setfade kommando sekunden übergibt. ich würde das gerne noch so öndern dass wir vom client gleich millisekunden an den streifen schicken, dann ist die berechnung einfacher (z.B. bei 64ms ein shift um 6 bit)
du musst jetzt im timer interrupt die ledstrip_update_fade aufrufen. das ist zumindest korrekter. muss aber auch nochmal im bezug auf performance überdacht werden.
werde ich als nöchstes machen
