### PR TITLE
Pic18 master

### DIFF
--- a/ClientSocket.cpp
+++ b/ClientSocket.cpp
@@ -50,7 +50,7 @@ TcpSocket::TcpSocket(const char* pAddr, short port)
 	}
 }
 
-int TcpSocket::Recv(char* pBuffer, size_t length) const
+int TcpSocket::Recv(unsigned char* pBuffer, size_t length) const
 {
 	return recv(mSock, pBuffer, length, 0);
 }
@@ -65,14 +65,14 @@ UdpSocket::UdpSocket(const char* pAddr, short port)
 {
 }
 
-int UdpSocket::Send(unsigned char* frame, size_t length) const
-{
-	return sendto(mSock, frame, length, 0, (struct sockaddr*)&mSockAddr, sizeof(mSockAddr));
-}
-
-int UdpSocket::Recv(char* pBuffer, size_t length) const
+int UdpSocket::Recv(unsigned char* pBuffer, size_t length) const
 {
 	std::cout << __FILE__ << ":" << __LINE__ << " Not implemented" << std::endl;
 	return -1;
+}
+
+int UdpSocket::Send(unsigned char* frame, size_t length) const
+{
+	return sendto(mSock, frame, length, 0, (struct sockaddr*)&mSockAddr, sizeof(mSockAddr));
 }
 

--- a/ClientSocket.h
+++ b/ClientSocket.h
@@ -37,7 +37,7 @@ class ClientSocket
 class TcpSocket : public ClientSocket
 {
 	public:
-		TcpSocket(const char* pAddr, short port);
+		TcpSocket(const char* pAddr = "127.0.0.1", short port = 2000);
 		virtual int Recv(char* pBuffer, size_t length) const;
 		virtual int Send(unsigned char* frame, size_t length) const;
 };
@@ -45,7 +45,7 @@ class TcpSocket : public ClientSocket
 class UdpSocket : public ClientSocket
 {
 	public:
-		UdpSocket(const char* pAddr, short port);
+		UdpSocket(const char* pAddr = "127.0.0.1", short port = 2000);
 		virtual int Recv(char* pBuffer, size_t length) const;
 		virtual int Send(unsigned char* frame, size_t length) const;
 };

--- a/ClientSocket.h
+++ b/ClientSocket.h
@@ -30,23 +30,23 @@ class ClientSocket
 	public:
 		ClientSocket(const char* pAddr, short port, int style);
 		virtual ~ClientSocket();
-		virtual int Recv(char* pBuffer, size_t length) const = 0;
+		virtual int Recv(unsigned char* pBuffer, size_t length) const = 0;
 		virtual int Send(unsigned char* frame, size_t length) const = 0;
 };
 
 class TcpSocket : public ClientSocket
 {
 	public:
-		TcpSocket(const char* pAddr = "127.0.0.1", short port = 2000);
-		virtual int Recv(char* pBuffer, size_t length) const;
+		TcpSocket(const char* pAddr, short port);
+		virtual int Recv(unsigned char* pBuffer, size_t length) const;
 		virtual int Send(unsigned char* frame, size_t length) const;
 };
 
 class UdpSocket : public ClientSocket
 {
 	public:
-		UdpSocket(const char* pAddr = "127.0.0.1", short port = 2000);
-		virtual int Recv(char* pBuffer, size_t length) const;
+		UdpSocket(const char* pAddr, short port);
+		virtual int Recv(unsigned char* pBuffer, size_t length) const;
 		virtual int Send(unsigned char* frame, size_t length) const;
 };
 #endif /* #ifndef _CLIENTSOCKET_H_ */

--- a/WiflyControl.cpp
+++ b/WiflyControl.cpp
@@ -30,7 +30,6 @@ void* RunReceiving(void* pObj)
 }
 
 WiflyControl::WiflyControl()
-//: mSock("127.0.0.1", 2000)
 : mSock("192.168.0.14", 2000)
 {
 	mCmdFrame.stx = STX;
@@ -38,7 +37,9 @@ WiflyControl::WiflyControl()
 	mCmdFrame.crcHigh = 0xDE;
 	mCmdFrame.crcLow = 0xAD;
 
+#ifndef USE_UDP
 	pthread_create(&mRecvThread, 0, RunReceiving, this);
+#endif
 }
 
 void WiflyControl::Receiving() const

--- a/WiflyControl.cpp
+++ b/WiflyControl.cpp
@@ -29,8 +29,8 @@ void* RunReceiving(void* pObj)
 	return NULL;
 }
 
-WiflyControl::WiflyControl()
-: mSock("192.168.0.14", 2000)
+WiflyControl::WiflyControl(const char* pAddr, short port)
+: mSock(pAddr, port)
 {
 	mCmdFrame.stx = STX;
 	mCmdFrame.length = (uns8)sizeof(struct cmd_set_color) + 2;
@@ -44,7 +44,7 @@ WiflyControl::WiflyControl()
 
 void WiflyControl::Receiving() const
 {
-	char buffer[2048];
+	unsigned char buffer[2048];
 	int bytesReceived;
 	for(;;)
 	{

--- a/WiflyControl.cpp
+++ b/WiflyControl.cpp
@@ -114,13 +114,14 @@ void WiflyControl::SetFade(unsigned long addr, unsigned long rgba, unsigned shor
 		<< (int)mCmdFrame.led.data.set_fade.blue << " : "
 		<< (int)mCmdFrame.led.data.set_fade.fadeTmms << std::endl;
 
+		unsigned int tempTmms = 0;
 		do
 		{
-			fadeTmms -= 1000;
-			std::cout << (int)fadeTmms/1000;
+			tempTmms += 1000;
+			std::cout << (int)tempTmms/1000;
 			std::cout.flush();
 			sleep(1); 
-		}while(fadeTmms > 0);
+		}while(tempTmms < fadeTmms);
 		std::cout << std::endl;
 #endif
 }

--- a/WiflyControl.h
+++ b/WiflyControl.h
@@ -37,7 +37,7 @@ class WiflyControl
 		unsigned long ToRGBA(std::string& s) const;
 		
 	public:
-		WiflyControl();
+		WiflyControl(const char* pAddr, short port);
 		void Receiving(void) const;
 		/**
 			rgba is a 32 Bit rgb value with alpha channel. Alpha is unused, but easier to handle

--- a/WiflyControlCli.cpp
+++ b/WiflyControlCli.cpp
@@ -18,11 +18,12 @@
 
 #include "WiflyControlCli.h"
 #include <iostream>
+#include <cstdlib>
 
 using namespace std;
 
-WiflyControlCli::WiflyControlCli(void)
-: mRunning(true)
+WiflyControlCli::WiflyControlCli(const char* pAddr, short port)
+: mControl(pAddr, port), mRunning(true)
 {
 }
 
@@ -75,7 +76,17 @@ void Java_biz_bruenn_WiflyLight_WiflyLightActivity_runClient(JNIEnv* env, jobjec
 
 int main(int argc, const char* argv[])
 {
-	WiflyControlCli cli;
+	const char* pAddr = "127.0.0.1";
+	short port = 2000;
+	if(argc > 1)
+	{
+		pAddr = argv[1];
+		if(argc > 2)
+		{
+			port = (short)atoi(argv[2]);
+		}
+	}
+	WiflyControlCli cli(pAddr, port);
 	cli.run();
 	return 0;
 }

--- a/WiflyControlCli.cpp
+++ b/WiflyControlCli.cpp
@@ -58,7 +58,7 @@ void WiflyControlCli::run(void)
 			cin >> addr;
 			cin >> color;
 			cin >> timevalue;
-			mControl.SetFade(addr, color, (unsigned short)timevalue * 1000);
+			mControl.SetFade(addr, color, (unsigned short)timevalue * 1024);
 		}
 	}
 }

--- a/WiflyControlCli.h
+++ b/WiflyControlCli.h
@@ -28,7 +28,7 @@ class WiflyControlCli
 		bool mRunning;
 
 	public:
-		WiflyControlCli(void);
+		WiflyControlCli(const char* pAddr, short port);
 		void run(void);	
 };
 #endif /* #ifndef _WIFLYCONTROLCLI_H_ */

--- a/commandstorage.c
+++ b/commandstorage.c
@@ -327,12 +327,6 @@ void Commandstorage_ExecuteCommands()
 	}
 }
 
-void Commandstorage_WaitInterrupt()
-{
-	if(g_CmdBuf.WaitValue != 0) 
-		g_CmdBuf.WaitValue = --g_CmdBuf.WaitValue;					
-}	
-
 void Commandstorage_Init()
 {
 	/** EEPROM contains FF in every cell after inital start,

--- a/commandstorage.c
+++ b/commandstorage.c
@@ -19,6 +19,7 @@
 #include "platform.h"
 #include "commandstorage.h"
 #include "ledstrip.h"
+#include "rtc.h"
 #include "trace.h"
 
 //*********************** PRIVATE FUNCTIONS *********************************************

--- a/commandstorage.h
+++ b/commandstorage.h
@@ -80,7 +80,11 @@ void Commandstorage_ExecuteCommands();
 **/
 void Commandstorage_Init();
 
-void Commandstorage_WaitInterrupt();
+#define Commandstorage_WaitInterrupt(x) \
+		do { \
+			if(g_CmdBuf.WaitValue != 0) \
+				g_CmdBuf.WaitValue = --g_CmdBuf.WaitValue; \
+		} while(0)
 
 #endif /* #ifndef _COMMANDSTORAGE_H_ */
 

--- a/ledstrip.c
+++ b/ledstrip.c
@@ -64,6 +64,7 @@ bank1 struct LedBuffer gLedBuf;
 			*(stepAddress) |= (stepMask); \
 		} else { \
 			delta = newColor - delta; \
+			*(stepAddress) &= ~(stepMask); \
 		}; \
 		INC_BIT_COUNTER(stepAddress, stepMask); \
 		gLedBuf.cyclesLeft[k] = 0; \
@@ -72,8 +73,8 @@ bank1 struct LedBuffer gLedBuf;
 			temp16 = fadeTmms / delta; \
 			gLedBuf.periodeLength[k] = temp16 / CYCLE_TMMS; \
 			gLedBuf.stepSize[k] = STEP_SIZE; \
-			gLedBuf.delta[k] = delta; \
 		} \
+		gLedBuf.delta[k] = delta; \
 };
 
 void Ledstrip_Init(void)
@@ -82,7 +83,11 @@ void Ledstrip_Init(void)
 	SPI_Init();
 	
 	// initialize variables
-	memset(gLedBuf.led_array, 0, sizeof(gLedBuf.led_array));
+	uns8 i = sizeof(gLedBuf.led_array);
+	do {
+		i--;
+		gLedBuf.led_array[i] = 0;
+	} while(0 != i);
 }
 
 void Ledstrip_SetColor(struct cmd_set_color *pCmd)
@@ -148,13 +153,6 @@ void Ledstrip_SetFade(struct cmd_set_fade *pCmd)
 {
 	// constant for this fade used in CALC_COLOR
 	const uns16 fadeTmms = ntohs(pCmd->fadeTmms);
-
-	/** TODO this permits parallel fade operations
-	    to fix this issue we have to move this into the CALC_COLOR
-			macro, but CC5x is not able to handle this large macros :-( 
-	*/
-	memset(gLedBuf.delta, 0, sizeof(gLedBuf.delta));
-	memset(gLedBuf.step, 0, sizeof(gLedBuf.step));
 
 	// calc fade parameters for each led
 	uns8 delta;

--- a/ledstrip.c
+++ b/ledstrip.c
@@ -19,6 +19,10 @@
 #include "ledstrip.h"
 #include "spi.h"
 
+#ifdef __CC8E__
+#include "MATH16.H"
+#endif /* #ifdef __CC8E__ */
+
 bank1 struct LedBuffer gLedBuf;
 
 /**

--- a/ledstrip.c
+++ b/ledstrip.c
@@ -148,7 +148,6 @@ void Ledstrip_SetFade(struct cmd_set_fade *pCmd)
 {
 	// constant for this fade used in CALC_COLOR
 	const uns16 fadeTmms = ntohs(pCmd->fadeTmms);
-	const uns16 fadeTmmsPerCycleTmms = fadeTmms / CYCLE_TMMS;	
 
 	/** TODO this permits parallel fade operations
 	    to fix this issue we have to move this into the CALC_COLOR

--- a/ledstrip.c
+++ b/ledstrip.c
@@ -67,17 +67,12 @@ bank1 struct LedBuffer gLedBuf;
 		}; \
 		INC_BIT_COUNTER(stepAddress, stepMask); \
 		gLedBuf.cyclesLeft[k] = 0; \
+		delta = delta / STEP_SIZE; \
 		if((0 != delta)) {\
-			temp16 = (uns16)delta * CYCLE_TMMS; \
-			if(fadeTmms >= temp16) { \
-				gLedBuf.periodeLength[k] = fadeTmmsPerCycleTmms / delta; \
-				gLedBuf.stepSize[k] = 1; \
-				gLedBuf.delta[k] = delta; \
-			} else { \
-				gLedBuf.periodeLength[k] = 1; \
-				gLedBuf.stepSize[k] = temp16 / fadeTmms; \
-				gLedBuf.delta[k] = fadeTmms / CYCLE_TMMS; \
-			} \
+			temp16 = fadeTmms / delta; \
+			gLedBuf.periodeLength[k] = temp16 / CYCLE_TMMS; \
+			gLedBuf.stepSize[k] = STEP_SIZE; \
+			gLedBuf.delta[k] = delta; \
 		} \
 };
 
@@ -144,6 +139,7 @@ void Ledstrip_DoFade(void)
 		}
 		INC_BIT_COUNTER(stepaddress, stepmask);
 	}
+
 	// write changes to ledstrip
 	SPI_SendLedBuffer(gLedBuf.led_array);
 }
@@ -151,23 +147,8 @@ void Ledstrip_DoFade(void)
 void Ledstrip_SetFade(struct cmd_set_fade *pCmd)
 {
 	// constant for this fade used in CALC_COLOR
-#ifdef X86
 	const uns16 fadeTmms = ntohs(pCmd->fadeTmms);
-#else
-	const uns16 fadeTmms = pCmd->fadeTmms;
-#endif
-
-	const uns16 fadeTmmsPerCycleTmms = fadeTmms / CYCLE_TMMS;
-#ifdef TEST_LED
-	UART_SendString("DoSETFADE ");
-	UART_SendString("fadeTmms = ");
-	UART_SendNumber(fadeTmms.high8,'H');
-	UART_SendNumber(fadeTmms.low8,'L');
-	UART_SendString("fadeTmmsPerCycleTmms = ");
-	UART_SendNumber(fadeTmmsPerCycleTmms.high8,'H');
-	UART_SendNumber(fadeTmmsPerCycleTmms.low8,'L');
-#endif
-	
+	const uns16 fadeTmmsPerCycleTmms = fadeTmms / CYCLE_TMMS;	
 
 	/** TODO this permits parallel fade operations
 	    to fix this issue we have to move this into the CALC_COLOR

--- a/main.c
+++ b/main.c
@@ -173,7 +173,7 @@ void InitAll()
 	Commandstorage_Init();
 	Error_Init();
 	Commandstorage_Clear();
-	Rtc_Init();
+	//Rtc_Init();
 
 #ifdef X86
 	init_x86();

--- a/main.c
+++ b/main.c
@@ -88,12 +88,7 @@ interrupt LowPriorityInterrupt(void)
 #ifdef TEST_RTC
 		g_Testvalue += 1;
 #endif
-		if(++g_TmmsCounter >= CYCLE_TMMS)
-		{
-			g_TmmsCounter = 0;
-			Ledstrip_UpdateFade();
-			Ledstrip_DoFade();
-		}
+		g_TmmsCounter++;
 	} 
 	if(TMR2IF)
 	{
@@ -152,7 +147,13 @@ void main(void)
 		Platform_CheckInputs();
 		Error_Throw();
 		Commandstorage_GetCommands();
-		Commandstorage_ExecuteCommands();
+		Commandstorage_ExecuteCommands();		
+		if(g_TmmsCounter >= CYCLE_TMMS)
+		{
+			g_TmmsCounter -= CYCLE_TMMS;
+			Ledstrip_UpdateFade();
+			Ledstrip_DoFade();
+		}
 #ifdef TEST_RTC		
 		if(g_Testvalue == 255)
 		{

--- a/main.c
+++ b/main.c
@@ -46,6 +46,7 @@
 #ifdef TEST_RTC
 uns8 g_Testvalue;
 #endif
+uns8 g_TmmsCounter;
 //*********************** FUNKTIONSPROTOTYPEN ****************************************
 void InitAll();
 void HighPriorityInterruptFunction(void);
@@ -87,13 +88,17 @@ interrupt LowPriorityInterrupt(void)
 #ifdef TEST_RTC
 		g_Testvalue += 1;
 #endif
-		Ledstrip_UpdateFade();
+		if(++g_TmmsCounter >= CYCLE_TMMS)
+		{
+			g_TmmsCounter = 0;
+			Ledstrip_UpdateFade();
+			Ledstrip_DoFade();
+		}
 	} 
 	if(TMR2IF)
 	{
 		Timer2Interrupt();
 
-		Ledstrip_DoFade();
 	}
 	
 	FSR0 = sv_FSR0;
@@ -136,6 +141,7 @@ void main(void)
 	clearRAM();
 #endif
 	InitAll();
+	g_TmmsCounter = 0;
 	
 	while(1)
 	{

--- a/main.c
+++ b/main.c
@@ -159,7 +159,7 @@ void InitAll()
 	Commandstorage_Init();
 	Error_Init();
 	Commandstorage_Clear();
-	//Rtc_Init();
+	Rtc_Init();
 
 	g_TmmsCounter = 0;
 

--- a/platform.h
+++ b/platform.h
@@ -25,7 +25,8 @@
 
 //*********************** CONFIGURATION ********************************************
 #define WIFLY_SERVER_PORT 2000 // TCP/UDP Port of Wifly device
-#define CYCLE_TMMS 64		//cycle time in milliseconds
+#define CYCLE_TMMS 64 //cycle time in milliseconds
+#define STEP_SIZE 16 //minimal stepSize while fading
 
 #ifdef X86
 	#include <stdio.h>

--- a/platform.h
+++ b/platform.h
@@ -47,7 +47,7 @@
 	#define Platform_DisableBootloaderAutostart(x)
 	#define InitFactoryRestoreWLAN(x)
 	#define InitFET(x)
-	#define Platform_IOInit(x)	
+	#define Platform_IOInit(x)
 	#define Platform_OsciInit(x)
 	
 #else
@@ -59,13 +59,6 @@
 
 	#define Platform_IOInit(x) do { CLRF(PORTB); CLRF(LATB); CLRF(ANSELB);} while(0) //Eingänge am PORTB initialisieren
 	#define Platform_OsciInit(x) do { OSCCON = 0b01110010; PLLEN = 1;} while(0) //OSZILLATOR initialisieren: 4xPLL deactivated;INTOSC 16MHz
-	
-	#define memset(PTR, VALUE, NUM_BYTES) do { \
-		short k; \
-		for(k = NUM_BYTES - 1; k >= 0; k--) { \
-			PTR[k] = VALUE; \
-		} \
-	} while(0)
 	
 	void Platform_AllowInterrupts();
 	

--- a/platform.h
+++ b/platform.h
@@ -25,7 +25,7 @@
 
 //*********************** CONFIGURATION ********************************************
 #define WIFLY_SERVER_PORT 2000 // TCP/UDP Port of Wifly device
-#define CYCLE_TMMS 4		//cycle time in milliseconds
+#define CYCLE_TMMS 64		//cycle time in milliseconds
 
 #ifdef X86
 	#include <stdio.h>

--- a/rtc.c
+++ b/rtc.c
@@ -16,12 +16,12 @@
  You should have received a copy of the GNU General Public License
  along with Wifly_Light.  If not, see <http://www.gnu.org/licenses/>. */
 
-#ifndef X86
 #include "rtc.h"
 #include "trace.h"
 #include "iic.h"
+#ifndef X86
 #include "INLINE.H"
-
+#endif
 
 //*********************** PRIVATE FUNCTIONS *********************************************
 
@@ -112,4 +112,3 @@ uns8 ioctl(uns8 fd,enum RTC_request req,struct rtc_time *pRtcTime)
 	return 0x00;
 }
 
-#endif

--- a/spi.c
+++ b/spi.c
@@ -74,6 +74,10 @@ void SPI_SendLedBuffer(uns8 *array)//!!! CHECK if GIE=0 during the sendroutine i
 	{
 		SPI_Send(*array);
 	}
+/* If we really have to garantee a sleep after data was written to the LEDs, it should be added here.
+ * Other locations would be more attractive to avoid a waiting core, but here it is much clearer and easier
+ * to find for later optimization. In my opinion we should spend this 1ms waste here, before we make the main
+ * loop more complex. */
 }
 #endif /* #ifndef X86 */
 

--- a/x86_wrapper.c
+++ b/x86_wrapper.c
@@ -24,6 +24,7 @@
 bit g_led_off = 1; //X86 replacement for PORTC.0
 pthread_mutex_t g_led_mutex = PTHREAD_MUTEX_INITIALIZER;
 uns8 g_led_status[NUM_OF_LED*3];
+extern uns8 g_TmmsCounter;
 
 void* InterruptRoutine(void* unused)
 {
@@ -71,9 +72,8 @@ void* timer_interrupt(void* unused)
 {
 	for(;;)
 	{
-		usleep(1000 * CYCLE_TMMS);
-		Ledstrip_UpdateFade();
-		Ledstrip_DoFade();
+		usleep(1000);
+		g_TmmsCounter++;
 	}
 }
 

--- a/x86_wrapper.c
+++ b/x86_wrapper.c
@@ -65,6 +65,7 @@ void Crc_NewCrc(unsigned char* p_crcH, unsigned char* p_crcL)
 }
 
 void I2C_Init(){}
+
 void Timer_Init(){}
 void timer_set_for_fade(char value){}
 void* timer_interrupt(void* unused)


### PR DESCRIPTION
Hi Nils,
Habe das Fade vereinfacht und jetzt sind auch parallele Fades möglich.
doFade/updateFade sind jetzt nicht mehr in der ISR wo sie massiv das Timerverhalten beeinflusst haben müssen sondern in der mainLoop. Der Timer zählt jetzt einen Millisekunden counter hoch. wenn dieser Counter die 64ms CYCLE_TMMS erreicht wird do und update Fade ausgeführt.
Im ledstrip.c habe ich mal math16 aktiviert.
Leider konnte ich die letzten Änderungen nicht auf dem PIC testen, weil ich schon in Bielefeld bin, aber das mit der ISR MUSS so gemacht werden. Wenn ich wieder in Fürth bin schaue ich mir das faden wieder an. Woran es liegt das sich der PIC und die SIMU so unterschiedlich verhalten.

Viele Grüße,
Patrick
