### PR TITLE
Pic18 master

### DIFF
--- a/RingBuf.h
+++ b/RingBuf.h
@@ -46,9 +46,9 @@ extern struct RingBuffer g_RingBuf;
  * Some macros 
  */
 #define RingBufInc(x) ((x + 1) & RingBufferSize)
-#define RingBufClearError(BUF) BUF ## .error_full = FALSE
-#define RingBuf_HasError(BUF) (BUF ## .error_full)
-#define RingBufIsNotEmpty(BUF) (BUF ## .write != BUF ## .read)
+#define RingBufClearError(BUF) BUF.error_full = FALSE
+#define RingBuf_HasError(BUF) (BUF.error_full)
+#define RingBufIsNotEmpty(BUF) (BUF.write != BUF.read)
 
 /**
  * Initialize the ring buffer and all associated variables

--- a/crc.c
+++ b/crc.c
@@ -96,7 +96,7 @@ void Crc_AddCrc(unsigned char byte,unsigned char* p_crcH,unsigned char* p_crcL)
  */
 void Crc_AddCrc16(unsigned char byte, unsigned short* pCrc)
 {
-	Crc_AddCrc(byte, (unsigned char*)pCrc, ((unsigned char*)pCrc + 1));
+	Crc_AddCrc(byte, ((unsigned char*)pCrc) + 1, (unsigned char*)pCrc);
 }
 
 void Crc_BuildCrc(unsigned char *data, unsigned char length, unsigned char* crcH_out, unsigned char* crcL_out)

--- a/x86_wrapper.c
+++ b/x86_wrapper.c
@@ -50,9 +50,9 @@ void* InterruptRoutine(void* unused)
 		int i;
 		for(i = 0; i < bytesRead; i++)
 		{
-			if(!RingBuf_HasError)
+			if(!RingBuf_HasError(g_RingBuf))
 			{
-				RingBuf_Put(buf[i]);
+				RingBuf_Put(&g_RingBuf, buf[i]);
 			}
 		}
 	}


### PR DESCRIPTION
Making RingBuf a "class" was a very good idea. The only thing i had to adjust was your makro usage
Macro(param) param ## something is not working with gcc! And not necessary as you can see with my solution. However its still not nice, because we cannot see if RingBufXYZ is a macro or a function. Next step should be to make all macros functions or at least adjust the macros to use pointers too! like:
Macro(param) (param)->something then we will call the macro exactly like the other RingBuf functions:

Macro(&g_RingBuf)

To Crc:
I fixed the problem. I was introduced, when I simplified the UnmaskControlCharacters function. Intheory Crc validation is very easy because if you add the crc to itself you get zero. So if crc in the bootloader response would be in network byte order we could just read all bytes one by one and add them to the crc checksum. And at the end the checksum has to be 0. But since the bootloader sends the low crc byte first this simple adding of bytes does not work (I didnt checked that before because I had no real HW in the train). To keep the crc calculation simple i just safe the last two versions of the crc so i have three crcs. crc is the current crc. preCrc is the previous crc without the latest added byte and prepreCrc is the crc before the last two bytes were added. To compare the checksum I just build the checksum for the full message and than just take prepreCrc which is the crc before the crc from the datastream was added. Now, i can add the datastream crc in the correct order and will get zero if the checksum is correct.
