### PR TITLE
fix a merge issue in x86_wrapper

### DIFF
--- a/commandstorage.c
+++ b/commandstorage.c
@@ -97,10 +97,7 @@ void Commandstorage_GetCommands()
                 {
 			if(ScriptCtrl_Add(&g_CmdBuf.cmd_buf[2]))
 			{
-			      Trace_String("GC");
-#ifdef __CC8E__
 			      UART_SendString("GC");
-#endif
 			}
 			else
 			{

--- a/main.c
+++ b/main.c
@@ -21,7 +21,9 @@
 #define TEST
 #pragma optimize 1
 #endif
+#ifdef __CC8E__
 #pragma sharedAllocation
+#endif
 
 //*********************** INCLUDEDATEIEN *********************************************
 #include "platform.h"
@@ -75,6 +77,7 @@ interrupt HighPriorityInterrupt(void)
 interrupt LowPriorityInterrupt(void)
 {
 	int_save_registers
+#if 0
 	uns16 sv_FSR0 = FSR0;
 	uns16 sv_FSR1 = FSR1;
 	uns16 sv_FSR2 = FSR2;
@@ -84,6 +87,7 @@ interrupt LowPriorityInterrupt(void)
 	uns8 sv_PRODH = PRODH;
 	uns24 sv_TBLPTR = TBLPTR;
 	uns8 sv_TABLAT = TABLAT;
+#endif
 
 	if(TMR5IF)
 	{
@@ -101,7 +105,7 @@ interrupt LowPriorityInterrupt(void)
 	      Timer1Disable();
 	      Timer1Interrupt();
 	}
-	
+#if 0	
 	FSR0 = sv_FSR0;
 	FSR1 = sv_FSR1;
 	FSR2 = sv_FSR2;
@@ -111,7 +115,7 @@ interrupt LowPriorityInterrupt(void)
 	PRODH = sv_PRODH;
 	TBLPTR = sv_TBLPTR;
 	TABLAT = sv_TABLAT;
-
+#endif
 	int_restore_registers
 }
 

--- a/timer.c
+++ b/timer.c
@@ -29,10 +29,11 @@ struct date_event gDateEvents[NUM_DATE_EVENTS];
 
 unsigned char date_timer_add_event(struct cmd_add_color* pCmd)
 {
+	static const unsigned short WAKEUP_UNUSED = 0xffff;
 	int i;
 	for(i = 0; i < NUM_DATE_EVENTS; i++)
 	{
-		if(0xffff == gDateEvents[i].wakeup)
+		if(WAKEUP_UNUSED == gDateEvents[i].wakeup)
 		{
 //TODO			uns16 hour = (uns16)pCmd->hour * 1800;
 			uns16 minute = (uns16)pCmd->minute * 30;

--- a/x86_wrapper.c
+++ b/x86_wrapper.c
@@ -50,7 +50,7 @@ void* InterruptRoutine(void* unused)
 		int i;
 		for(i = 0; i < bytesRead; i++)
 		{
-			if(!RingBuf_HasError(g_RingBuf))
+			if(!RingBuf_HasError(&g_RingBuf))
 			{
 				RingBuf_Put(&g_RingBuf, buf[i]);
 			}


### PR DESCRIPTION
removed x86 trace of "GC" message
fix some compiler warnings
- register saving in main.c deactivated
- weird warning at timer.c omited by using a static const instead of a literal
