### PR TITLE
Bugfix #34

### DIFF
--- a/WiflyControl.cpp
+++ b/WiflyControl.cpp
@@ -488,7 +488,7 @@ void WiflyControl::SetFade(unsigned long addr, unsigned long rgba, unsigned shor
 	mCmdFrame.length = sizeof(cmd_set_fade) + 3;
 	mCmdFrame.led.cmd = SET_FADE;
 	SetAddrRgb(mCmdFrame.led.data.set_fade, addr, rgba);
-	mCmdFrame.led.data.set_fade.fadeTmms = fadeTmms;
+	mCmdFrame.led.data.set_fade.fadeTmms = htons(fadeTmms);
 	mCmdFrame.led.data.set_fade.parallelFade = parallelFade;
 	FwSend(&mCmdFrame);
 }

--- a/WiflyControl.cpp
+++ b/WiflyControl.cpp
@@ -400,15 +400,13 @@ void WiflyControl::FwTest(void)
 	static const unsigned long BLUE  = 0x0000FF00;
 	static const unsigned long WHITE = 0xFFFFFF00;
 	static const unsigned long BLACK = 0x00000000;
-	while(doRun)
-	{
-		SetColor(0xFFFFFFFFLU, BLACK);
-		SetColor(0xFF000000LU, RED);   sleep(1);
-		SetColor(0x00FF0000LU, GREEN); sleep(1);
-		SetColor(0x0000FF00LU, BLUE);  sleep(1);
-		SetColor(0x000000FFLU, WHITE); sleep(1);
-		SetFade (0xFFFFFFFFLU, 0x00000000LU, 5000);
-	}
+
+	SetColor(0xFFFFFFFFLU, BLACK);
+	SetColor(0xFF000000LU, RED);   sleep(1);
+	SetColor(0x00FF0000LU, GREEN); sleep(1);
+	SetColor(0x0000FF00LU, BLUE);  sleep(1);
+	SetColor(0x000000FFLU, WHITE); sleep(1);
+	SetFade (0xFFFFFFFFLU, 0x00000000LU, 5000);
 }
 
 void WiflyControl::StartBl(void)

--- a/ledstrip.h
+++ b/ledstrip.h
@@ -37,7 +37,7 @@ struct LedBuffer{
 	uns16 cyclesLeft[NUM_OF_LED * 3];
 	uns16 periodeLength[NUM_OF_LED * 3];
 	uns8 step[NUM_OF_LED / 8 * 3];
-	uns8 stepSize[NUM_OF_LED];
+	uns8 stepSize[NUM_OF_LED * 3];
 	uns16 fadeTmms;
 	struct status_bits{
 		uns8 run_aktiv : 1;


### PR DESCRIPTION
#34 was caused by a bufferoverflow, because stepSize was not large enough to keep sizes for all leds and rgb colors but only for the leds
