### PR TITLE
removed boost usage

### DIFF
--- a/BroadcastReceiver.cpp
+++ b/BroadcastReceiver.cpp
@@ -49,7 +49,7 @@ void BroadcastReceiver::operator()(void)
 {
 	UdpSocket udpSock(0x7f000001, mPort, true);
 	sockaddr_storage remoteAddr;
-	size_t remoteAddrLength = sizeof(remoteAddr);
+	socklen_t remoteAddrLength = sizeof(remoteAddr);
 	
 	for(;;)
 	{

--- a/BroadcastReceiver.cpp
+++ b/BroadcastReceiver.cpp
@@ -101,14 +101,9 @@ void BroadcastReceiver::ShowRemotes(std::ostream& out) const
 void BroadcastReceiver::Stop(void)
 {
 	try {
-		std::ostringstream converter;
-		converter << mPort;
 		boost::asio::io_service io_service;
 		udp::socket sock(io_service, udp::endpoint(udp::v4(), 0));
-		udp::resolver resolver(io_service);
-		udp::resolver::query query(udp::v4(), "127.0.0.1", converter.str());
-		udp::resolver::iterator it = resolver.resolve(query);
-		sock.send_to(boost::asio::buffer(STOP_MSG, STOP_MSG_LENGTH), *it);
+		sock.send_to(boost::asio::buffer(STOP_MSG, STOP_MSG_LENGTH), udp::endpoint(udp::v4(), mPort));
 		mThread.join();
 	} catch (std::exception& e) {
 		std::cout << __FUNCTION__ << ':' <<  e.what() << '\n';

--- a/BroadcastReceiver.cpp
+++ b/BroadcastReceiver.cpp
@@ -72,12 +72,12 @@ void BroadcastReceiver::operator()(void)
 	}
 }
 
-unsigned long BroadcastReceiver::GetIp(size_t index) const
+uint32_t BroadcastReceiver::GetIp(size_t index) const
 {
 	return mIpTable[index].address().to_v4().to_ulong();
 }
 
-unsigned short BroadcastReceiver::GetPort(size_t index) const
+uint16_t BroadcastReceiver::GetPort(size_t index) const
 {
 	return mIpTable[index].port();
 }

--- a/BroadcastReceiver.cpp
+++ b/BroadcastReceiver.cpp
@@ -19,6 +19,7 @@
 #include "BroadcastReceiver.h"
 
 #include <cstring>
+#include <functional>
 #include <iostream>
 #include <stdio.h>
 #include <sstream>
@@ -86,16 +87,13 @@ size_t BroadcastReceiver::NumRemotes(void) const
 	return mIpTable.size();
 }
 
-void Print(boost::asio::ip::udp::endpoint remote)
-{
-	static size_t i = 0;
-	std::cout << i << ':' << remote << '\n';
-}
-
 void BroadcastReceiver::ShowRemotes(std::ostream& out) const
 {
-	
-	for_each(mIpTable.begin(), mIpTable.end(), Print);
+	size_t index = 0;
+	for(vector<udp::endpoint>::const_iterator it = mIpTable.begin(); it != mIpTable.end(); *it++, index++)
+	{
+		out << index << ':' << *it << '\n';
+	}
 }
 
 void BroadcastReceiver::Stop(void)

--- a/BroadcastReceiver.h
+++ b/BroadcastReceiver.h
@@ -19,13 +19,12 @@
 #ifndef _BROADCAST_RECEIVER_H_
 #define _BROADCAST_RECEIVER_H_
 
+#include "ClientSocket.h"
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <map>
 #include <string>
 #include <vector>
-#include <boost/asio.hpp>
-using boost::asio::ip::udp;
 
 #include <boost/thread.hpp>
 #include <stdint.h> //TODO use "cstdint" if c++11 compiler is available
@@ -118,7 +117,7 @@ class BroadcastReceiver
 		void Stop(void);
 
 	private:
-		vector<udp::endpoint> mIpTable;
+		vector<Endpoint*> mIpTable;
 		boost::thread mThread;
 		boost::mutex mMutex;
 };

--- a/BroadcastReceiver.h
+++ b/BroadcastReceiver.h
@@ -92,13 +92,23 @@ class BroadcastReceiver
 		~BroadcastReceiver(void);
 
 		/**
-		 * Main loop wait for wifly broadcast messages and save them to the known IP list
+		 * Endless loop collecting wifly broadcast messages and save them to the
+		 * known IP list. Terminate execution by calling <Stop()>
 		 */
 		void operator()(void);
 
 		uint32_t GetIp(size_t index) const;
 		uint16_t GetPort(size_t index) const;
+
+		/**
+		 * @return number of known IP addresses
+		 */
 		size_t NumRemotes(void) const;
+
+		/**
+		 * Print remote list to outputstream
+		 * @param out outputstream
+		 */
 		void ShowRemotes(std::ostream& out) const;
 
 		/**

--- a/BroadcastReceiver.h
+++ b/BroadcastReceiver.h
@@ -23,10 +23,10 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <map>
+#include <ostream>
 #include <string>
 #include <vector>
-
-#include <boost/thread.hpp>
+#include <pthread.h>
 #include <stdint.h> //TODO use "cstdint" if c++11 compiler is available
 
 using std::vector;
@@ -118,8 +118,8 @@ class BroadcastReceiver
 
 	private:
 		vector<Endpoint*> mIpTable;
-		boost::thread mThread;
-		boost::mutex mMutex;
+		pthread_t mThread;
+		pthread_mutex_t mMutex;
 };
 
 #endif /* #ifndef _BROADCAST_RECEIVER_H_ */

--- a/BroadcastReceiver.h
+++ b/BroadcastReceiver.h
@@ -25,11 +25,12 @@
 #include <string>
 #include <vector>
 #include <boost/asio.hpp>
+using boost::asio::ip::udp;
+
 #include <boost/thread.hpp>
 #include <stdint.h> //TODO use "cstdint" if c++11 compiler is available
 
 using std::vector;
-using boost::asio::ip::udp;
 
 #pragma pack(push)
 #pragma pack(1)

--- a/BroadcastReceiver.h
+++ b/BroadcastReceiver.h
@@ -26,6 +26,7 @@
 #include <vector>
 #include <boost/asio.hpp>
 #include <boost/thread.hpp>
+#include <stdint.h> //TODO use "cstdint" if c++11 compiler is available
 
 using std::vector;
 using boost::asio::ip::udp;
@@ -34,18 +35,18 @@ using boost::asio::ip::udp;
 #pragma pack(1)
 struct BroadcastMessage
 {
-	unsigned char mac[6];
-	unsigned char channel;
-	unsigned char rssi;
-	unsigned short port;
-	unsigned long rtc;
-	unsigned short bat_mV;
-	unsigned short gpioValue;
+	uint8_t mac[6];
+	uint8_t channel;
+	uint8_t rssi;
+	uint16_t port;
+	uint32_t rtc;
+	uint16_t bat_mV;
+	uint16_t gpioValue;
 	char asciiTime[13+1];
 	char version[26+1+1];// this seems a little strange. bug in wifly fw?
 	char deviceId[32];
-	unsigned short bootTmms;
-	unsigned short sensor[8];
+	uint16_t bootTmms;
+	uint16_t sensor[8];
 
 	void NetworkToHost(void) {
 		port = ntohs(port);
@@ -80,14 +81,14 @@ struct BroadcastMessage
 class BroadcastReceiver
 {
 	public:
-		static const unsigned short BROADCAST_PORT = 55555;
+		static const uint16_t BROADCAST_PORT = 55555;
 		static const char BROADCAST_DEVICE_ID[];
 		static const size_t BROADCAST_DEVICE_ID_LENGTH;
 		static const char STOP_MSG[];
 		static const size_t STOP_MSG_LENGTH;
-		const unsigned short mPort;
+		const uint16_t mPort;
 
-		BroadcastReceiver(unsigned short port);
+		BroadcastReceiver(uint16_t port);
 		~BroadcastReceiver(void);
 
 		/**
@@ -95,8 +96,8 @@ class BroadcastReceiver
 		 */
 		void operator()(void);
 
-		unsigned long GetIp(size_t index) const;
-		unsigned short GetPort(size_t index) const;
+		uint32_t GetIp(size_t index) const;
+		uint16_t GetPort(size_t index) const;
 		size_t NumRemotes(void) const;
 		void ShowRemotes(std::ostream& out) const;
 

--- a/BroadcastReceiver.h
+++ b/BroadcastReceiver.h
@@ -25,9 +25,10 @@
 #include <string>
 #include <vector>
 #include <boost/asio.hpp>
-using boost::asio::ip::udp;
 #include <boost/thread.hpp>
 
+using std::vector;
+using boost::asio::ip::udp;
 
 #pragma pack(push)
 #pragma pack(1)
@@ -105,7 +106,7 @@ class BroadcastReceiver
 		void Stop(void);
 
 	private:
-		std::vector<boost::asio::ip::udp::endpoint> mIpTable;
+		vector<udp::endpoint> mIpTable;
 		boost::thread mThread;
 		boost::mutex mMutex;
 };

--- a/BroadcastReceiver.h
+++ b/BroadcastReceiver.h
@@ -88,7 +88,7 @@ class BroadcastReceiver
 		static const size_t STOP_MSG_LENGTH;
 		const uint16_t mPort;
 
-		BroadcastReceiver(uint16_t port);
+		BroadcastReceiver(uint16_t port = BROADCAST_PORT);
 		~BroadcastReceiver(void);
 
 		/**

--- a/BroadcastReceiver_ut.cpp
+++ b/BroadcastReceiver_ut.cpp
@@ -45,7 +45,7 @@ unsigned char capturedBroadcastMessage[110] = {
 int ut_BroadcastReceiver_TestEmpty(void)
 {
 	TestCaseBegin();
-	BroadcastReceiver dummyReceiver(55555);
+	BroadcastReceiver dummyReceiver;
 	CHECK(0 == dummyReceiver.NumRemotes());
 	TestCaseEnd();
 }
@@ -56,12 +56,10 @@ int ut_BroadcastReceiver_TestSimple(void)
 	try {
 		boost::asio::io_service io_service;
 		udp::socket sock(io_service, udp::endpoint(udp::v4(), 0));
-		udp::resolver resolver(io_service);
-		udp::resolver::query query(udp::v4(), "127.0.0.1", "55555");
-		udp::resolver::iterator it = resolver.resolve(query);
-		BroadcastReceiver dummyReceiver(55555);
+		udp::endpoint remote(udp::v4(), BroadcastReceiver::BROADCAST_PORT);
+		BroadcastReceiver dummyReceiver;
 		sleep(1);
-		sock.send_to(boost::asio::buffer(capturedBroadcastMessage, sizeof(capturedBroadcastMessage)), *it);
+		sock.send_to(boost::asio::buffer(capturedBroadcastMessage, sizeof(capturedBroadcastMessage)), remote);
 		dummyReceiver.Stop();
 
 		CHECK(1 == dummyReceiver.NumRemotes());

--- a/BroadcastReceiver_ut.cpp
+++ b/BroadcastReceiver_ut.cpp
@@ -60,6 +60,7 @@ int ut_BroadcastReceiver_TestSimple(void)
 	dummyReceiver.Stop();
 
 	CHECK(1 == dummyReceiver.NumRemotes());
+	CHECK(0x7F000001 == dummyReceiver.GetIp(0));
 	TestCaseEnd();
 }
 

--- a/BroadcastReceiver_ut.cpp
+++ b/BroadcastReceiver_ut.cpp
@@ -21,6 +21,8 @@
 #include "ClientSocket.h"
 #include <vector>
 #include <iostream>
+#include <unistd.h>
+
 using std::vector;
 
 unsigned char capturedBroadcastMessage[110] = {
@@ -46,6 +48,7 @@ int ut_BroadcastReceiver_TestEmpty(void)
 	TestCaseBegin();
 	BroadcastReceiver dummyReceiver;
 	CHECK(0 == dummyReceiver.NumRemotes());
+	sleep(1);
 	TestCaseEnd();
 }
 

--- a/BroadcastReceiver_ut.cpp
+++ b/BroadcastReceiver_ut.cpp
@@ -18,11 +18,10 @@
 
 #include "unittest.h"
 #include "BroadcastReceiver.h"
-#include <boost/asio.hpp>
+#include "ClientSocket.h"
 #include <vector>
 #include <iostream>
 using std::vector;
-using boost::asio::ip::udp;
 
 unsigned char capturedBroadcastMessage[110] = {
 0x00, 0x0f, 0xb5, 0xb2, 0x57, 0xfa, //MAC
@@ -53,20 +52,14 @@ int ut_BroadcastReceiver_TestEmpty(void)
 int ut_BroadcastReceiver_TestSimple(void)
 {
 	TestCaseBegin();
-	try {
-		boost::asio::io_service io_service;
-		udp::socket sock(io_service, udp::endpoint(udp::v4(), 0));
-		udp::endpoint remote(udp::v4(), BroadcastReceiver::BROADCAST_PORT);
-		BroadcastReceiver dummyReceiver;
-		sleep(1);
-		sock.send_to(boost::asio::buffer(capturedBroadcastMessage, sizeof(capturedBroadcastMessage)), remote);
-		dummyReceiver.Stop();
 
-		CHECK(1 == dummyReceiver.NumRemotes());
-	} catch (std::exception& e) {
-		std::cout << __FUNCTION__ << ':' <<  e.what() << '\n';
-		errors++;
-	}
+	UdpSocket udpSock(0x7f000001, BroadcastReceiver::BROADCAST_PORT, false);
+	BroadcastReceiver dummyReceiver;
+	sleep(1);
+	udpSock.Send(capturedBroadcastMessage, sizeof(capturedBroadcastMessage));
+	dummyReceiver.Stop();
+
+	CHECK(1 == dummyReceiver.NumRemotes());
 	TestCaseEnd();
 }
 

--- a/ClientSocket.cpp
+++ b/ClientSocket.cpp
@@ -106,6 +106,11 @@ size_t UdpSocket::Recv(unsigned char* pBuffer, size_t length, timeval* timeout) 
 	return 0;
 }
 
+size_t UdpSocket::RecvFrom(unsigned char* pBuffer, size_t length, timeval* timeout, struct sockaddr* remoteAddr, size_t* remoteAddrLength) const
+{
+	return recvfrom(mSock, pBuffer, length, 0, remoteAddr, remoteAddrLength);
+}
+
 int UdpSocket::Send(const unsigned char* frame, size_t length) const
 {
 #ifdef DEBUG

--- a/ClientSocket.cpp
+++ b/ClientSocket.cpp
@@ -104,7 +104,7 @@ size_t UdpSocket::Recv(unsigned char* pBuffer, size_t length, timeval* timeout) 
 	return 0;
 }
 
-size_t UdpSocket::RecvFrom(unsigned char* pBuffer, size_t length, timeval* timeout, struct sockaddr* remoteAddr, size_t* remoteAddrLength) const
+size_t UdpSocket::RecvFrom(unsigned char* pBuffer, size_t length, timeval* timeout, struct sockaddr* remoteAddr, socklen_t* remoteAddrLength) const
 {
 	return recvfrom(mSock, pBuffer, length, 0, remoteAddr, remoteAddrLength);
 }

--- a/ClientSocket.cpp
+++ b/ClientSocket.cpp
@@ -37,9 +37,7 @@ ClientSocket::ClientSocket(unsigned long addr, unsigned short port, int style)
 
 ClientSocket::~ClientSocket()
 {
-#ifndef ANDROID
 	close(mSock);
-#endif
 }
 
 TcpSocket::TcpSocket(unsigned long addr, unsigned short port)

--- a/ClientSocket.cpp
+++ b/ClientSocket.cpp
@@ -89,10 +89,10 @@ int TcpSocket::Send(const unsigned char* frame, size_t length) const
 	return send(mSock, frame, length, 0);
 }
 
-UdpSocket::UdpSocket(unsigned long addr, unsigned short port)
+UdpSocket::UdpSocket(unsigned long addr, unsigned short port, bool doBind)
 	: ClientSocket(addr, port, SOCK_DGRAM)
 {
-	if(0 != bind(mSock, reinterpret_cast<struct sockaddr *>(&mSockAddr), sizeof(struct sockaddr)))
+	if(doBind && 0 != bind(mSock, reinterpret_cast<struct sockaddr *>(&mSockAddr), sizeof(struct sockaddr)))
 	{
 	      std::cout << __FILE__ << ":" << __FUNCTION__ << ": Bind failure! ";
 	      pthread_exit(NULL);

--- a/ClientSocket.h
+++ b/ClientSocket.h
@@ -63,7 +63,7 @@ class UdpSocket : public ClientSocket
 	public:
 		UdpSocket(unsigned long addr, unsigned short port, bool doBind = true);
 		virtual size_t Recv(unsigned char* pBuffer, size_t length, timeval* timeout = NULL) const;
-		virtual size_t RecvFrom(unsigned char* pBuffer, size_t length, timeval* timeout = NULL, struct sockaddr* remoteAddr = NULL, size_t* remoteAddrLength = NULL) const;
+		virtual size_t RecvFrom(unsigned char* pBuffer, size_t length, timeval* timeout = NULL, struct sockaddr* remoteAddr = NULL, socklen_t* remoteAddrLength = NULL) const;
 		virtual int Send(const unsigned char* frame, size_t length) const;
 };
 

--- a/ClientSocket.h
+++ b/ClientSocket.h
@@ -18,10 +18,24 @@
 
 #ifndef _CLIENTSOCKET_H_
 #define _CLIENTSOCKET_H_
+#include <cassert>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <stddef.h>
 #include <sys/time.h>
+
+class Endpoint
+{
+	public:
+		Endpoint(sockaddr_storage& addr, const size_t size) {
+			assert(sizeof(sockaddr_in) == size);
+			m_Addr = ntohl(((sockaddr_in&)addr).sin_addr.s_addr);
+			m_Port = ntohs(((sockaddr_in&)addr).sin_port);
+		};
+		Endpoint(uint32_t addr, uint16_t port) : m_Addr(addr), m_Port(port) {};
+		uint32_t m_Addr;
+		uint16_t m_Port;
+};
 
 class ClientSocket
 {
@@ -49,6 +63,7 @@ class UdpSocket : public ClientSocket
 	public:
 		UdpSocket(unsigned long addr, unsigned short port, bool doBind = true);
 		virtual size_t Recv(unsigned char* pBuffer, size_t length, timeval* timeout = NULL) const;
+		virtual size_t RecvFrom(unsigned char* pBuffer, size_t length, timeval* timeout = NULL, struct sockaddr* remoteAddr = NULL, size_t* remoteAddrLength = NULL) const;
 		virtual int Send(const unsigned char* frame, size_t length) const;
 };
 

--- a/ClientSocket.h
+++ b/ClientSocket.h
@@ -47,7 +47,7 @@ class TcpSocket : public ClientSocket
 class UdpSocket : public ClientSocket
 {
 	public:
-		UdpSocket(unsigned long addr, unsigned short port);
+		UdpSocket(unsigned long addr, unsigned short port, bool doBind = true);
 		virtual size_t Recv(unsigned char* pBuffer, size_t length, timeval* timeout = NULL) const;
 		virtual int Send(const unsigned char* frame, size_t length) const;
 };

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,10 @@ x86_client_debug:
 	@gcc $< $(subst _ut.c,.c,$<) eeprom.c -DX86 -DUNIT_TEST -o $@ -Wall
 	@./$@
 
-BroadcastReceiver_ut.bin: BroadcastReceiver_ut.cpp BroadcastReceiver.cpp BroadcastReceiver.h unittest.h
+%.o: %.cpp %.h
+	g++ $< $(subst .o,.cpp,$<) -DX86 -o $@ -Wall
+
+BroadcastReceiver_ut.bin: BroadcastReceiver_ut.cpp BroadcastReceiver.cpp BroadcastReceiver.h ClientSocket.cpp ClientSocket.h unittest.h
 	@g++ BroadcastReceiver_ut.cpp BroadcastReceiver.cpp ClientSocket.cpp -DX86 -DUNIT_TEST -lpthread -lboost_system -lboost_thread -o $@ -Wall
 	@./$@
 

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ x86_client_debug:
 	@./$@
 
 BroadcastReceiver_ut.bin: BroadcastReceiver_ut.cpp BroadcastReceiver.cpp BroadcastReceiver.h unittest.h
-	@g++ BroadcastReceiver_ut.cpp BroadcastReceiver.cpp -DX86 -DUNIT_TEST -lpthread -lboost_system -lboost_thread -o $@ -Wall
+	@g++ BroadcastReceiver_ut.cpp BroadcastReceiver.cpp ClientSocket.cpp -DX86 -DUNIT_TEST -lpthread -lboost_system -lboost_thread -o $@ -Wall
 	@./$@
 
 ComProxy_ut.bin: ComProxy_ut.cpp ComProxy.cpp ComProxy.h BlRequest.h unittest.h

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ANDROID_BIN=android/.metadata ${ANDROID_DIR}/bin/ ${ANDROID_DIR}/gen/ ${ANDROID_
 
 X86_SRC=main.c crc.c commandstorage.c eeprom.c error.c ledstrip.c RingBuf.c ScriptCtrl.c spi.c timer.c usart.c x86_wrapper.c x86_gl.c
 
-X86_CLIENT_BUILD=g++ BroadcastReceiver.cpp ClientSocket.cpp ComProxy.cpp intelhexclass.cpp WiflyControl.cpp WiflyControlCli.cpp crc.c -DX86 -lpthread -o client.bin -Wall -pedantic -std=c++11
+X86_CLIENT_BUILD=g++ BroadcastReceiver.cpp ClientSocket.cpp ComProxy.cpp crc.c intelhexclass.cpp WiflyControl.cpp WiflyControlCli.cpp -DX86 -lpthread -o client.bin -Wall -pedantic -std=c++11
 
 all_nils: pic simu x86_client
 

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ x86_client_debug:
 	g++ $< $(subst .o,.cpp,$<) -DX86 -o $@ -Wall
 
 BroadcastReceiver_ut.bin: BroadcastReceiver_ut.cpp BroadcastReceiver.cpp BroadcastReceiver.h ClientSocket.cpp ClientSocket.h unittest.h
-	@g++ BroadcastReceiver_ut.cpp BroadcastReceiver.cpp ClientSocket.cpp -DX86 -DUNIT_TEST -lpthread -lboost_system -lboost_thread -o $@ -Wall
+	@g++ BroadcastReceiver_ut.cpp BroadcastReceiver.cpp ClientSocket.cpp -DX86 -DUNIT_TEST -lpthread -o $@ -Wall -std=c++11
 	@./$@
 
 ComProxy_ut.bin: ComProxy_ut.cpp ComProxy.cpp ComProxy.h BlRequest.h unittest.h

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ANDROID_BIN=android/.metadata ${ANDROID_DIR}/bin/ ${ANDROID_DIR}/gen/ ${ANDROID_
 
 X86_SRC=main.c crc.c commandstorage.c eeprom.c error.c ledstrip.c RingBuf.c ScriptCtrl.c spi.c timer.c usart.c x86_wrapper.c x86_gl.c
 
-X86_CLIENT_BUILD=g++ BroadcastReceiver.cpp ClientSocket.cpp ComProxy.cpp intelhexclass.cpp WiflyControl.cpp WiflyControlCli.cpp crc.c -DX86 -lpthread -lboost_system -lboost_thread -o client.bin -Wall -pedantic
+X86_CLIENT_BUILD=g++ BroadcastReceiver.cpp ClientSocket.cpp ComProxy.cpp intelhexclass.cpp WiflyControl.cpp WiflyControlCli.cpp crc.c -DX86 -lpthread -o client.bin -Wall -pedantic -std=c++11
 
 all_nils: pic simu x86_client
 

--- a/WiflyControlCli.cpp
+++ b/WiflyControlCli.cpp
@@ -95,15 +95,20 @@ int main(int argc, const char* argv[])
 	}
 	cout << '\n';
 	receiver.Stop();
+	if(0 == receiver.NumRemotes()) {
+		std::cout << "No remote found, exiting...\n";
+		return EXIT_FAILURE;
+	}
+
 	receiver.ShowRemotes(std::cout);
 
 	// wait for user input
 	size_t selection;
-	std::cin >> selection;
-	if(receiver.NumRemotes() < selection) {
-		cout << selection << " is an invalid value\n";
-		return EXIT_FAILURE;
-	}
+	do
+	{
+		std::cin >> selection;
+	} while(selection >= receiver.NumRemotes());
+
 	WiflyControlCli cli(receiver.GetIp(selection), receiver.GetPort(selection), true);
 	cli.Run();
 }

--- a/WiflyControlCli.cpp
+++ b/WiflyControlCli.cpp
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <iostream>
+#include <unistd.h>
 #include <vector>
 
 using std::cout;

--- a/android/WiflyLight/jni/Android.mk
+++ b/android/WiflyLight/jni/Android.mk
@@ -1,10 +1,15 @@
 LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
-
+DIR := ../../../
 LOCAL_LDLIBS := -llog
 LOCAL_CFLAGS := -DX86 -DANDROID
 LOCAL_MODULE := wifly
-LOCAL_SRC_FILES := ../../../ClientSocket.cpp
+LOCAL_SRC_FILES := $(DIR)BroadcastReceiver.cpp
+LOCAL_SRC_FILES += $(DIR)ClientSocket.cpp
+LOCAL_SRC_FILES += $(DIR)ComProxy.cpp
+LOCAL_SRC_FILES += $(DIR)crc.c
+LOCAL_SRC_FILES += $(DIR)intelhexclass.cpp
+LOCAL_SRC_FILES += $(DIR)WiflyControl.cpp
 
 include $(BUILD_SHARED_LIBRARY)

--- a/android/WiflyLight/jni/Application.mk
+++ b/android/WiflyLight/jni/Application.mk
@@ -1,1 +1,2 @@
 APP_STL := stlport_static
+APP_CPPFLAGS := -std=gnu++0x

--- a/crc.c
+++ b/crc.c
@@ -86,10 +86,16 @@ void Crc_AddCrc(unsigned char byte,unsigned char* p_crcH,unsigned char* p_crcL)
  * crc value. In a next refactoring step we should replace that other functions
  * with this one.
  */
+#ifdef __cplusplus
+extern "C" {
+#endif
 void Crc_AddCrc16(unsigned char byte, unsigned short* pCrc)
 {
 	Crc_AddCrc(byte, ((unsigned char*)pCrc) + 1, (unsigned char*)pCrc);
 }
+#ifdef __cplusplus
+}
+#endif
 
 void Crc_BuildCrc(const unsigned char *data, unsigned char length, unsigned char* crcH_out, unsigned char* crcL_out)
 {

--- a/crc.h
+++ b/crc.h
@@ -31,9 +31,13 @@
 //adds one byte to the given crc checksum
 void Crc_AddCrc(unsigned char byte,unsigned char* p_crcH,unsigned char* p_crcL);
 
+#ifdef __cplusplus
 extern "C" {
+#endif
 void Crc_AddCrc16(unsigned char byte,unsigned short* pCrc);
+#ifdef __cplusplus
 }
+#endif
 
 //do a complete crc calulation 
 void Crc_BuildCrc(const unsigned char *data, unsigned char length, unsigned char* crcH_out, unsigned char* crcL_out);

--- a/crc.h
+++ b/crc.h
@@ -30,7 +30,10 @@
 
 //adds one byte to the given crc checksum
 void Crc_AddCrc(unsigned char byte,unsigned char* p_crcH,unsigned char* p_crcL);
+
+extern "C" {
 void Crc_AddCrc16(unsigned char byte,unsigned short* pCrc);
+}
 
 //do a complete crc calulation 
 void Crc_BuildCrc(const unsigned char *data, unsigned char length, unsigned char* crcH_out, unsigned char* crcL_out);

--- a/todo.txt
+++ b/todo.txt
@@ -1,0 +1,3 @@
+
+Improvement: fix rules in Makefile
+- build objects end dependencies


### PR DESCRIPTION
Hi Nils,
ich habe jetzt boost wieder rausgeworfen, weil ich es unter android nicht sauber zum laufen bekommen habe. ich denke fpr den kleinkram den wir damit gemacht haben (sockets und threads) brauchen wir es auch erstmal nicht. Gerade wenn wir so exotische sachen wie ios und android unterstützen wollen, sollten wir uns nicht die komplexitöt von boost ans bein binden. sorry für den aufwand, den ich da verursacht habe.
Ich konte jetzt die komplette wifly lbrary mit den andoid ndk bauen und werde morgen anfangen alle funktionen aus java aufzurufen.
