### PR TITLE
BroadcastReceiver

### DIFF
--- a/BroadcastReceiver.cpp
+++ b/BroadcastReceiver.cpp
@@ -53,7 +53,6 @@ void BroadcastReceiver::operator() (std::ostream& out, unsigned short timeout)
 		} while((0 != remote) && (time(NULL) < endTime));
 	}
 	std::atomic_fetch_sub(&mNumInstances, 1);
-	out << "exit" << std::endl;
 }
 #endif /* #ifndef OS_ANDROID */
 
@@ -75,7 +74,7 @@ uint32_t BroadcastReceiver::GetNextRemote(void)
 		size_t bytesRead = udpSock.RecvFrom((unsigned char*)&msg, sizeof(msg), NULL, (sockaddr*)&remoteAddr, &remoteAddrLength);
 		if(msg.IsWiflyBroadcast(bytesRead))
 		{
-			Endpoint* newRemote = new Endpoint(remoteAddr, remoteAddrLength);
+			Endpoint* newRemote = new Endpoint(remoteAddr, remoteAddrLength, msg.port);
 #ifndef OS_ANDROID
 			mMutex.lock();
 			mIpTable.push_back(newRemote);
@@ -94,7 +93,7 @@ uint32_t BroadcastReceiver::GetNextRemote(void)
 
 uint16_t BroadcastReceiver::GetPort(size_t index) const
 {
-	return 2000;//mIpTable[index]->m_Port;
+	return mIpTable[index]->m_Port;
 }
 
 size_t BroadcastReceiver::NumRemotes(void) const

--- a/BroadcastReceiver.cpp
+++ b/BroadcastReceiver.cpp
@@ -36,6 +36,7 @@ BroadcastReceiver::~BroadcastReceiver(void)
 	//TODO cleanup mIpTable
 }
 
+#ifndef OS_ANDROID
 void BroadcastReceiver::operator() (std::ostream& out, unsigned short timeout)
 {
 	// only one thread allowed per instance
@@ -54,6 +55,7 @@ void BroadcastReceiver::operator() (std::ostream& out, unsigned short timeout)
 	std::atomic_fetch_sub(&mNumInstances, 1);
 	out << "exit" << std::endl;
 }
+#endif /* #ifndef OS_ANDROID */
 
 uint32_t BroadcastReceiver::GetIp(size_t index) const
 {
@@ -73,10 +75,13 @@ uint32_t BroadcastReceiver::GetNextRemote(void)
 		if(msg.IsWiflyBroadcast(bytesRead))
 		{
 			Endpoint* newRemote = new Endpoint(remoteAddr, remoteAddrLength);
+#ifndef OS_ANDROID
 			mMutex.lock();
 			mIpTable.push_back(newRemote);
-			std::cout << "HUHU " << mIpTable.size() << ':' << NumRemotes() << '\n';
 			mMutex.unlock();
+#else
+			mIpTable.push_back(newRemote);
+#endif /* #ifndef OS_ANDROID */
 			return newRemote->m_Addr;
 		}
 		else if(msg.IsStop(bytesRead))

--- a/BroadcastReceiver.cpp
+++ b/BroadcastReceiver.cpp
@@ -94,7 +94,7 @@ uint32_t BroadcastReceiver::GetNextRemote(void)
 
 uint16_t BroadcastReceiver::GetPort(size_t index) const
 {
-	return mIpTable[index]->m_Port;
+	return 2000;//mIpTable[index]->m_Port;
 }
 
 size_t BroadcastReceiver::NumRemotes(void) const

--- a/BroadcastReceiver.cpp
+++ b/BroadcastReceiver.cpp
@@ -101,15 +101,6 @@ size_t BroadcastReceiver::NumRemotes(void) const
 	return mIpTable.size();
 }
 
-void BroadcastReceiver::ShowRemotes(std::ostream& out) const
-{
-	size_t index = 0;
-	for(vector<Endpoint*>::const_iterator it = mIpTable.begin(); it != mIpTable.end(); *it++, index++)
-	{
-		out << index << ':' << std::hex << (*it)->m_Addr << '\n';
-	}
-}
-
 void BroadcastReceiver::Stop(void)
 {
 	UdpSocket sock(INADDR_LOOPBACK, mPort, false);

--- a/BroadcastReceiver.cpp
+++ b/BroadcastReceiver.cpp
@@ -32,7 +32,7 @@ BroadcastReceiver::BroadcastReceiver(unsigned short port)
 
 BroadcastReceiver::~BroadcastReceiver(void)
 {
-	//Stop();
+	Stop();
 	//TODO cleanup mIpTable
 }
 

--- a/BroadcastReceiver.h
+++ b/BroadcastReceiver.h
@@ -32,6 +32,51 @@
 
 using std::vector;
 
+class BroadcastReceiver
+{
+	public:
+		static const uint16_t BROADCAST_PORT = 55555;
+		static const char BROADCAST_DEVICE_ID[];
+		static const size_t BROADCAST_DEVICE_ID_LENGTH;
+		static const char STOP_MSG[];
+		static const size_t STOP_MSG_LENGTH;
+		const uint16_t mPort;
+
+		BroadcastReceiver(uint16_t port = BROADCAST_PORT);
+		~BroadcastReceiver(void);
+
+		/**
+		 * Endless loop collecting wifly broadcast messages and save them to the
+		 * known IP list. Terminate execution by calling <Stop()>
+		 */
+		void operator()(void);
+
+		uint32_t GetIp(size_t index) const;
+		uint32_t GetNextRemote(void);
+		uint16_t GetPort(size_t index) const;
+
+		/**
+		 * @return number of known IP addresses
+		 */
+		size_t NumRemotes(void) const;
+
+		/**
+		 * Print remote list to outputstream
+		 * @param out outputstream
+		 */
+		void ShowRemotes(std::ostream& out) const;
+
+		/**
+		 * Sends a stop event to terminate execution of operator()
+		 */
+		void Stop(void);
+
+	private:
+		vector<Endpoint*> mIpTable;
+		pthread_t mThread;
+		pthread_mutex_t mMutex;
+};
+
 #pragma pack(push)
 #pragma pack(1)
 struct BroadcastMessage
@@ -49,6 +94,13 @@ struct BroadcastMessage
 	uint16_t bootTmms;
 	uint16_t sensor[8];
 
+	bool IsWiflyBroadcast(size_t length) {
+		return ((sizeof(BroadcastMessage) == length) && (0 == memcmp(deviceId,	BroadcastReceiver::BROADCAST_DEVICE_ID, BroadcastReceiver::BROADCAST_DEVICE_ID_LENGTH)));
+	};
+
+// was used only for debugging
+// deactivated because of possible byte order issues using IsWiflyBroadcast()
+#if 0 
 	void NetworkToHost(void) {
 		port = ntohs(port);
 		rtc = ntohl(rtc);
@@ -76,51 +128,7 @@ struct BroadcastMessage
 		<< "\nDeviceID: " << deviceId
 		<< "\nBoottime: " << std::dec << bootTmms << "ms\n";
 	};
+#endif
 };
 #pragma pack(pop)
-
-class BroadcastReceiver
-{
-	public:
-		static const uint16_t BROADCAST_PORT = 55555;
-		static const char BROADCAST_DEVICE_ID[];
-		static const size_t BROADCAST_DEVICE_ID_LENGTH;
-		static const char STOP_MSG[];
-		static const size_t STOP_MSG_LENGTH;
-		const uint16_t mPort;
-
-		BroadcastReceiver(uint16_t port = BROADCAST_PORT);
-		~BroadcastReceiver(void);
-
-		/**
-		 * Endless loop collecting wifly broadcast messages and save them to the
-		 * known IP list. Terminate execution by calling <Stop()>
-		 */
-		void operator()(void);
-
-		uint32_t GetIp(size_t index) const;
-		uint16_t GetPort(size_t index) const;
-
-		/**
-		 * @return number of known IP addresses
-		 */
-		size_t NumRemotes(void) const;
-
-		/**
-		 * Print remote list to outputstream
-		 * @param out outputstream
-		 */
-		void ShowRemotes(std::ostream& out) const;
-
-		/**
-		 * Sends a stop event to terminate execution of operator()
-		 */
-		void Stop(void);
-
-	private:
-		vector<Endpoint*> mIpTable;
-		pthread_t mThread;
-		pthread_mutex_t mMutex;
-};
-
 #endif /* #ifndef _BROADCAST_RECEIVER_H_ */

--- a/BroadcastReceiver.h
+++ b/BroadcastReceiver.h
@@ -20,9 +20,11 @@
 #define _BROADCAST_RECEIVER_H_
 
 #include "ClientSocket.h"
+#include <atomic>
 #include <cstdint>
 #include <cstring>
 #include <map>
+#include <mutex>
 #include <ostream>
 #include <pthread.h>
 #include <string>
@@ -74,8 +76,8 @@ class BroadcastReceiver
 
 	private:
 		vector<Endpoint*> mIpTable;
-		pthread_t mThread;
-		pthread_mutex_t mMutex;
+		std::atomic<int> mNumInstances;
+		std::mutex mMutex;
 };
 
 #pragma pack(push)
@@ -97,6 +99,11 @@ struct BroadcastMessage
 
 	bool IsWiflyBroadcast(size_t length) {
 		return ((sizeof(BroadcastMessage) == length) && (0 == memcmp(deviceId,	BroadcastReceiver::BROADCAST_DEVICE_ID, BroadcastReceiver::BROADCAST_DEVICE_ID_LENGTH)));
+	};
+
+	bool IsStop(size_t length) {
+		return ((BroadcastReceiver::STOP_MSG_LENGTH == length)
+						&& (0 == memcmp(&mac, BroadcastReceiver::STOP_MSG, BroadcastReceiver::STOP_MSG_LENGTH)));
 	};
 
 // was used only for debugging

--- a/BroadcastReceiver.h
+++ b/BroadcastReceiver.h
@@ -65,12 +65,6 @@ class BroadcastReceiver
 		size_t NumRemotes(void) const;
 
 		/**
-		 * Print remote list to outputstream
-		 * @param out outputstream
-		 */
-		void ShowRemotes(std::ostream& out) const;
-
-		/**
 		 * Sends a stop event to terminate execution of operator()
 		 */
 		void Stop(void);

--- a/BroadcastReceiver.h
+++ b/BroadcastReceiver.h
@@ -20,17 +20,16 @@
 #define _BROADCAST_RECEIVER_H_
 
 #include "ClientSocket.h"
-#include <atomic>
 #include <cstdint>
 #include <cstring>
-#include <map>
-#include <mutex>
 #include <ostream>
-#include <pthread.h>
 #include <string>
 #include <vector>
-#include <netinet/in.h>
-#include <sys/socket.h>
+
+#ifndef OS_ANDROID
+#include <atomic>
+#include <mutex>
+#endif /* #ifndef OS_ANDROID */
 
 using std::vector;
 
@@ -47,12 +46,14 @@ class BroadcastReceiver
 		BroadcastReceiver(uint16_t port = BROADCAST_PORT);
 		~BroadcastReceiver(void);
 
+#ifndef OS_ANDROID
 		/**
 		 * Wait for broadcasts and print them to a stream
 		 * @param out stream to print collected remotes on
 		 * @param timeout in seconds, until execution is terminated
 		 */
 		void operator() (std::ostream& out, unsigned short timeout);
+#endif /* #ifndef OS_ANDROID */
 
 		uint32_t GetIp(size_t index) const;
 		uint32_t GetNextRemote(void);
@@ -76,8 +77,12 @@ class BroadcastReceiver
 
 	private:
 		vector<Endpoint*> mIpTable;
+#ifndef OS_ANDROID
 		std::atomic<int> mNumInstances;
 		std::mutex mMutex;
+#else
+		int mNumInstances;
+#endif /* #ifndef OS_ANDROID */
 };
 
 #pragma pack(push)

--- a/BroadcastReceiver.h
+++ b/BroadcastReceiver.h
@@ -20,15 +20,15 @@
 #define _BROADCAST_RECEIVER_H_
 
 #include "ClientSocket.h"
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <stdint.h>
+#include <cstdint>
+#include <cstring>
 #include <map>
 #include <ostream>
+#include <pthread.h>
 #include <string>
 #include <vector>
-#include <pthread.h>
-#include <stdint.h> //TODO use "cstdint" if c++11 compiler is available
+#include <netinet/in.h>
+#include <sys/socket.h>
 
 using std::vector;
 
@@ -46,10 +46,11 @@ class BroadcastReceiver
 		~BroadcastReceiver(void);
 
 		/**
-		 * Endless loop collecting wifly broadcast messages and save them to the
-		 * known IP list. Terminate execution by calling <Stop()>
+		 * Wait for broadcasts and print them to a stream
+		 * @param out stream to print collected remotes on
+		 * @param timeout in seconds, until execution is terminated
 		 */
-		void operator()(void);
+		void operator() (std::ostream& out, unsigned short timeout);
 
 		uint32_t GetIp(size_t index) const;
 		uint32_t GetNextRemote(void);

--- a/ClientSocket.h
+++ b/ClientSocket.h
@@ -27,10 +27,10 @@
 class Endpoint
 {
 	public:
-		Endpoint(sockaddr_storage& addr, const size_t size) {
+		Endpoint(sockaddr_storage& addr, const size_t size, unsigned short port) {
 			assert(sizeof(sockaddr_in) == size);
 			m_Addr = ntohl(((sockaddr_in&)addr).sin_addr.s_addr);
-			m_Port = ntohs(((sockaddr_in&)addr).sin_port);
+			m_Port = ntohs(port);
 		};
 		Endpoint(uint32_t addr, uint16_t port) : m_Addr(addr), m_Port(port) {};
 		uint32_t m_Addr;

--- a/WiflyControlCli.cpp
+++ b/WiflyControlCli.cpp
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <iostream>
+#include <thread>
 #include <unistd.h>
 #include <vector>
 
@@ -75,34 +76,13 @@ void WiflyControlCli::ShowHelp(void) const
 	return;
 }
 
-#ifdef ANDROID
-#include <jni.h>
-extern "C" {
-void Java_biz_bruenn_WiflyLight_WiflyLightActivity_runClient(JNIEnv* env, jobject ref)
-{
-	WiflyControl control;
-	colorLoop(control);
-}
-}
-#endif
-
 int main(int argc, const char* argv[])
 {
 	BroadcastReceiver receiver(55555);
-	cout << "please wait, scanning for remotes...";
-	for(size_t timeout = 9; timeout > 0; timeout--) {
-		(cout << timeout << ' ').flush();
-		sleep(1);
-	}
-	cout << '\n';
-	receiver.Stop();
-	if(0 == receiver.NumRemotes()) {
-		std::cout << "No remote found, exiting...\n";
-		return EXIT_FAILURE;
-	}
+	std::thread t(receiver, std::ref(cout), 3);
 
-	receiver.ShowRemotes(std::cout);
-
+	t.join();
+#if 0
 	// wait for user input
 	size_t selection;
 	do
@@ -112,4 +92,5 @@ int main(int argc, const char* argv[])
 
 	WiflyControlCli cli(receiver.GetIp(selection), receiver.GetPort(selection), true);
 	cli.Run();
+#endif
 }

--- a/WiflyControlCli.cpp
+++ b/WiflyControlCli.cpp
@@ -31,6 +31,7 @@ using std::cout;
 WiflyControlCli::WiflyControlCli(unsigned long addr, unsigned short port, bool useTcp)
 : mControl(addr, port, useTcp), mRunning(true)
 {
+	cout << "Connecting to " << std::hex << addr << ':' << port << std::endl;
 }
 
 void WiflyControlCli::Run(void)
@@ -79,18 +80,18 @@ void WiflyControlCli::ShowHelp(void) const
 int main(int argc, const char* argv[])
 {
 	BroadcastReceiver receiver(55555);
-	std::thread t(receiver, std::ref(cout), 3);
+	std::thread t(std::ref(receiver), std::ref(cout), 10);
 
-	t.join();
-#if 0
 	// wait for user input
 	size_t selection;
 	do
 	{
 		std::cin >> selection;
+		cout << selection << " of " << receiver.NumRemotes() << '\n';
 	} while(selection >= receiver.NumRemotes());
 
+	receiver.Stop();
+	t.join();
 	WiflyControlCli cli(receiver.GetIp(selection), receiver.GetPort(selection), true);
 	cli.Run();
-#endif
 }

--- a/WiflyControlCli.cpp
+++ b/WiflyControlCli.cpp
@@ -87,7 +87,6 @@ int main(int argc, const char* argv[])
 	do
 	{
 		std::cin >> selection;
-		cout << selection << " of " << receiver.NumRemotes() << '\n';
 	} while(selection >= receiver.NumRemotes());
 
 	receiver.Stop();

--- a/WiflyControlJni.cpp
+++ b/WiflyControlJni.cpp
@@ -21,20 +21,25 @@
 #include <jni.h>
 
 extern "C" {
-jlong Java_biz_bruenn_WiflyLight_WiflyLightActivity_getNumRemotes(JNIEnv* env, jobject ref, jlong pNative)
+jlong Java_biz_bruenn_WiflyLight_RemoteCollector_getNumRemotes(JNIEnv* env, jobject ref, jlong pNative)
 {
-	sleep(5);
+	//sleep(2);
 	return ((BroadcastReceiver*)pNative)->NumRemotes();
 }
 
-jlong Java_biz_bruenn_WiflyLight_WiflyLightActivity_createBroadcastReceiver(JNIEnv* env, jobject ref)
+jlong Java_biz_bruenn_WiflyLight_RemoteCollector_createBroadcastReceiver(JNIEnv* env, jobject ref)
 {
 	return (jlong) new BroadcastReceiver(BroadcastReceiver::BROADCAST_PORT);
 }
 
-void Java_biz_bruenn_WiflyLight_WiflyLightActivity_releaseBroadcastReceiver(JNIEnv* env, jobject ref, jlong pNative)
+void Java_biz_bruenn_WiflyLight_RemoteCollector_releaseBroadcastReceiver(JNIEnv* env, jobject ref, jlong pNative)
 {
 	delete (BroadcastReceiver*)pNative;
+}
+
+jlong Java_biz_bruenn_WiflyLight_RemoteCollector_getNextRemote(JNIEnv* env, jobject ref, jlong pNative)
+{
+	return ((BroadcastReceiver*)pNative)->GetNextRemote();
 }
 }
 

--- a/WiflyControlJni.cpp
+++ b/WiflyControlJni.cpp
@@ -21,11 +21,20 @@
 #include <jni.h>
 
 extern "C" {
-unsigned long int Java_biz_bruenn_WiflyLight_WiflyLightActivity_getNumRemotes(JNIEnv* env, jobject ref)
+jlong Java_biz_bruenn_WiflyLight_WiflyLightActivity_getNumRemotes(JNIEnv* env, jobject ref, jlong pNative)
 {
-	BroadcastReceiver receiver;
-	sleep(3);
-	return receiver.NumRemotes();
+	sleep(5);
+	return ((BroadcastReceiver*)pNative)->NumRemotes();
+}
+
+jlong Java_biz_bruenn_WiflyLight_WiflyLightActivity_createBroadcastReceiver(JNIEnv* env, jobject ref)
+{
+	return (jlong) new BroadcastReceiver(BroadcastReceiver::BROADCAST_PORT);
+}
+
+void Java_biz_bruenn_WiflyLight_WiflyLightActivity_releaseBroadcastReceiver(JNIEnv* env, jobject ref, jlong pNative)
+{
+	delete (BroadcastReceiver*)pNative;
 }
 }
 

--- a/android/WiflyLight/jni/Android.mk
+++ b/android/WiflyLight/jni/Android.mk
@@ -3,7 +3,7 @@ LOCAL_PATH := $(call my-dir)
 include $(CLEAR_VARS)
 DIR := ../../../
 LOCAL_LDLIBS := -llog
-LOCAL_CFLAGS := -DX86 -DANDROID
+LOCAL_CFLAGS := -DX86 -DOS_ANDROID
 LOCAL_MODULE := wifly
 LOCAL_SRC_FILES := $(DIR)BroadcastReceiver.cpp
 LOCAL_SRC_FILES += $(DIR)ClientSocket.cpp

--- a/android/WiflyLight/res/layout/main.xml
+++ b/android/WiflyLight/res/layout/main.xml
@@ -14,5 +14,9 @@
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:text="@string/hello" />
+    <ListView
+        android:id="@+id/remoteList"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent" />
 
 </LinearLayout>

--- a/android/WiflyLight/res/layout/main.xml
+++ b/android/WiflyLight/res/layout/main.xml
@@ -4,6 +4,11 @@
     android:layout_height="fill_parent"
     android:orientation="vertical" >
 
+	<Button
+        android:id="@+id/scan"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/scan" />
     <TextView
         android:id="@+id/debugOutput"
         android:layout_width="fill_parent"

--- a/android/WiflyLight/res/values/strings.xml
+++ b/android/WiflyLight/res/values/strings.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <string name="hello">Hello World, WiflyLightActivity!</string>
     <string name="app_name">WiflyLight</string>
+    <string name="hello">Hello World, WiflyLightActivity!</string>
+    <string name="scan">Scan...</string>
 
 </resources>

--- a/android/WiflyLight/res/values/strings.xml
+++ b/android/WiflyLight/res/values/strings.xml
@@ -3,6 +3,7 @@
 
     <string name="app_name">WiflyLight</string>
     <string name="hello">Hello World, WiflyLightActivity!</string>
-    <string name="scan">Scan...</string>
+    <string name="scan">Scan</string>
+    <string name="scanning">Scanning...</string>
 
 </resources>

--- a/android/WiflyLight/src/biz/bruenn/WiflyLight/RemoteCollector.java
+++ b/android/WiflyLight/src/biz/bruenn/WiflyLight/RemoteCollector.java
@@ -1,0 +1,63 @@
+package biz.bruenn.WiflyLight;
+
+import java.util.ArrayList;
+import biz.bruenn.WiflyLight.R.string;
+
+import android.net.wifi.WifiManager;
+import android.os.AsyncTask;
+import android.widget.ArrayAdapter;
+import android.widget.Button;
+
+public class RemoteCollector extends AsyncTask<Long, Void, Void> {
+	private native long createBroadcastReceiver();
+	private native long getNumRemotes(long pNative);
+	private native long getNextRemote(long pNative);
+	private native void releaseBroadcastReceiver(long pNative);
+	
+	private ArrayAdapter<String> mRemoteArrayAdapter;
+	private ArrayList<String> mRemoteArray;
+	private WifiManager.MulticastLock mMulticastLock; 
+	private long mNative = 0;
+	private Button mScanBtn;
+	protected RemoteCollector mMe = this;
+	
+	public RemoteCollector(WifiManager wifiMgr, ArrayList<String> remoteArray, ArrayAdapter<String> remoteArrayAdapter, Button scanBtn) {
+		mMulticastLock = wifiMgr.createMulticastLock("WiflyLight_MulticastLock");
+		mNative = createBroadcastReceiver();
+		mRemoteArray = remoteArray;
+		mRemoteArrayAdapter = remoteArrayAdapter;
+		mScanBtn = scanBtn;
+	}
+	
+	public void finalize() throws Throwable {
+		releaseBroadcastReceiver(mNative);
+	}
+
+	public void run() {
+	}
+
+	@Override
+	protected Void doInBackground(Long... params) {
+		long timeoutTmms = params[0];
+		final long endTime = timeoutTmms + System.currentTimeMillis();
+		
+		mMulticastLock.acquire();
+		while(!isCancelled() && System.currentTimeMillis() < endTime) {
+			mRemoteArray.add(String.valueOf(getNextRemote(mNative)));
+			publishProgress();
+		}
+		mMulticastLock.release();
+		return null;
+	}
+
+	@Override
+	protected void onProgressUpdate(Void... progress) {
+		mRemoteArrayAdapter.notifyDataSetChanged();
+	}
+	
+	@Override
+	protected void onPostExecute(Void result) {
+		mScanBtn.setClickable(true);
+		mScanBtn.setText(string.scan);
+	}
+}

--- a/android/WiflyLight/src/biz/bruenn/WiflyLight/RemoteCollector.java
+++ b/android/WiflyLight/src/biz/bruenn/WiflyLight/RemoteCollector.java
@@ -19,7 +19,6 @@ public class RemoteCollector extends AsyncTask<Long, Void, Void> {
 	private WifiManager.MulticastLock mMulticastLock; 
 	private long mNative = 0;
 	private Button mScanBtn;
-	protected RemoteCollector mMe = this;
 	
 	public RemoteCollector(WifiManager wifiMgr, ArrayList<String> remoteArray, ArrayAdapter<String> remoteArrayAdapter, Button scanBtn) {
 		mMulticastLock = wifiMgr.createMulticastLock("WiflyLight_MulticastLock");

--- a/android/WiflyLight/src/biz/bruenn/WiflyLight/WiflyLightActivity.java
+++ b/android/WiflyLight/src/biz/bruenn/WiflyLight/WiflyLightActivity.java
@@ -1,11 +1,14 @@
 package biz.bruenn.WiflyLight;
 
+import biz.bruenn.WiflyLight.R.id;
 import android.app.Activity;
 import android.content.Context;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.net.wifi.WifiManager;
 import android.os.Bundle;
+import android.view.View;
+import android.widget.Button;
 import android.widget.TextView;
 
 public class WiflyLightActivity extends Activity {
@@ -22,23 +25,32 @@ public class WiflyLightActivity extends Activity {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.main);
-   
-        WifiManager wifiMgr = (WifiManager)getSystemService(Context.WIFI_SERVICE);
-        if(wifiMgr != null) {
-        	WifiManager.MulticastLock lock = wifiMgr.createMulticastLock("WiflyLight_MulticastLock");
-        	lock.acquire();
+        
+        Button scanBtn = (Button)findViewById(id.scan);
+        scanBtn.setOnClickListener(new View.OnClickListener() {
+			
+			public void onClick(View v) {
+				// TODO Auto-generated method stub
+				WifiManager wifiMgr = (WifiManager)getSystemService(Context.WIFI_SERVICE);
+				if(wifiMgr != null) {
+					WifiManager.MulticastLock lock = wifiMgr.createMulticastLock("WiflyLight_MulticastLock");
+					lock.acquire();
 
-	        ConnectivityManager connMgr = (ConnectivityManager)getSystemService(Context.CONNECTIVITY_SERVICE);
-	        NetworkInfo info = connMgr.getActiveNetworkInfo();
-	        TextView debug = (TextView)findViewById(R.id.debugOutput);
-	        if(null != info && info.isConnected()) {
-	        	long pNative = createBroadcastReceiver();
-	        	debug.setText("b " + String.valueOf(getNumRemotes(pNative)));
-	        	releaseBroadcastReceiver(pNative);
-	        } else {
-	        	debug.setText("no network connection found");
-	        }
-	        lock.release();
-        }
+					ConnectivityManager connMgr = (ConnectivityManager)getSystemService(Context.CONNECTIVITY_SERVICE);
+					NetworkInfo info = connMgr.getActiveNetworkInfo();
+					TextView debug = (TextView)findViewById(R.id.debugOutput);
+					if(null != info && info.isConnected()) {
+						long pNative = createBroadcastReceiver();
+						debug.setText("b " + String.valueOf(getNumRemotes(pNative)));
+						releaseBroadcastReceiver(pNative);
+					} else {
+						debug.setText("no network connection found");
+					}
+					lock.release();
+				}
+			}
+		});
+   
+        
     }
 }

--- a/android/WiflyLight/src/biz/bruenn/WiflyLight/WiflyLightActivity.java
+++ b/android/WiflyLight/src/biz/bruenn/WiflyLight/WiflyLightActivity.java
@@ -3,21 +3,17 @@ package biz.bruenn.WiflyLight;
 import java.util.ArrayList;
 
 import biz.bruenn.WiflyLight.R.id;
+import biz.bruenn.WiflyLight.R.string;
 import android.app.Activity;
 import android.content.Context;
-import android.net.ConnectivityManager;
-import android.net.NetworkInfo;
 import android.net.wifi.WifiManager;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.ListView;
-import android.widget.TextView;
 
 public class WiflyLightActivity extends Activity {
-	
-	private RemoteCollector mRemoteCollector;
 	private ListView mRemoteList;
 	private ArrayList<String> mRemoteArray = new ArrayList<String>();
 	ArrayAdapter<String> mRemoteArrayAdapter;
@@ -32,33 +28,21 @@ public class WiflyLightActivity extends Activity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.main);
 
-        mRemoteArray.add("1");
-        mRemoteArray.add("2");
         mRemoteList = (ListView)findViewById(id.remoteList);
         mRemoteArrayAdapter = new ArrayAdapter<String>(this, android.R.layout.simple_list_item_1, mRemoteArray);
-        mRemoteCollector = new RemoteCollector(mRemoteArrayAdapter);
         mRemoteList.setAdapter(mRemoteArrayAdapter);
-       
         
         Button scanBtn = (Button)findViewById(id.scan);
         scanBtn.setOnClickListener(new View.OnClickListener() {
 			
 			public void onClick(View v) {
-				WifiManager wifiMgr = (WifiManager)getSystemService(Context.WIFI_SERVICE);
-				if(wifiMgr != null) {
-					WifiManager.MulticastLock lock = wifiMgr.createMulticastLock("WiflyLight_MulticastLock");
-					lock.acquire();
-
-					ConnectivityManager connMgr = (ConnectivityManager)getSystemService(Context.CONNECTIVITY_SERVICE);
-					NetworkInfo info = connMgr.getActiveNetworkInfo();
-					TextView debug = (TextView)findViewById(R.id.debugOutput);
-					if(null != info && info.isConnected()) {
-						mRemoteCollector.run();
-					} else {
-						debug.setText("no network connection found");
-					}
-					lock.release();
-				}
+				Button btn = (Button)v;
+				btn.setClickable(false);
+				btn.setText(string.scanning);
+				new RemoteCollector((WifiManager)getSystemService(Context.WIFI_SERVICE), 
+						mRemoteArray,
+						mRemoteArrayAdapter,
+						btn).execute(Long.valueOf(3000));
 			}
 		});
     }

--- a/android/WiflyLight/src/biz/bruenn/WiflyLight/WiflyLightActivity.java
+++ b/android/WiflyLight/src/biz/bruenn/WiflyLight/WiflyLightActivity.java
@@ -9,7 +9,9 @@ import android.os.Bundle;
 import android.widget.TextView;
 
 public class WiflyLightActivity extends Activity {
-	private native long getNumRemotes();
+	private native long createBroadcastReceiver();
+	private native long getNumRemotes(long pNative);
+	private native void releaseBroadcastReceiver(long pNative);
 	
 	static {
 		System.loadLibrary("wifly");
@@ -30,7 +32,9 @@ public class WiflyLightActivity extends Activity {
 	        NetworkInfo info = connMgr.getActiveNetworkInfo();
 	        TextView debug = (TextView)findViewById(R.id.debugOutput);
 	        if(null != info && info.isConnected()) {
-	        	debug.setText("y " + String.valueOf(getNumRemotes()));
+	        	long pNative = createBroadcastReceiver();
+	        	debug.setText("b " + String.valueOf(getNumRemotes(pNative)));
+	        	releaseBroadcastReceiver(pNative);
 	        } else {
 	        	debug.setText("no network connection found");
 	        }

--- a/android/WiflyLight/src/biz/bruenn/WiflyLight/WiflyLightActivity.java
+++ b/android/WiflyLight/src/biz/bruenn/WiflyLight/WiflyLightActivity.java
@@ -1,5 +1,7 @@
 package biz.bruenn.WiflyLight;
 
+import java.util.ArrayList;
+
 import biz.bruenn.WiflyLight.R.id;
 import android.app.Activity;
 import android.content.Context;
@@ -8,13 +10,17 @@ import android.net.NetworkInfo;
 import android.net.wifi.WifiManager;
 import android.os.Bundle;
 import android.view.View;
+import android.widget.ArrayAdapter;
 import android.widget.Button;
+import android.widget.ListView;
 import android.widget.TextView;
 
 public class WiflyLightActivity extends Activity {
-	private native long createBroadcastReceiver();
-	private native long getNumRemotes(long pNative);
-	private native void releaseBroadcastReceiver(long pNative);
+	
+	private RemoteCollector mRemoteCollector;
+	private ListView mRemoteList;
+	private ArrayList<String> mRemoteArray = new ArrayList<String>();
+	ArrayAdapter<String> mRemoteArrayAdapter;
 	
 	static {
 		System.loadLibrary("wifly");
@@ -25,12 +31,19 @@ public class WiflyLightActivity extends Activity {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.main);
+
+        mRemoteArray.add("1");
+        mRemoteArray.add("2");
+        mRemoteList = (ListView)findViewById(id.remoteList);
+        mRemoteArrayAdapter = new ArrayAdapter<String>(this, android.R.layout.simple_list_item_1, mRemoteArray);
+        mRemoteCollector = new RemoteCollector(mRemoteArrayAdapter);
+        mRemoteList.setAdapter(mRemoteArrayAdapter);
+       
         
         Button scanBtn = (Button)findViewById(id.scan);
         scanBtn.setOnClickListener(new View.OnClickListener() {
 			
 			public void onClick(View v) {
-				// TODO Auto-generated method stub
 				WifiManager wifiMgr = (WifiManager)getSystemService(Context.WIFI_SERVICE);
 				if(wifiMgr != null) {
 					WifiManager.MulticastLock lock = wifiMgr.createMulticastLock("WiflyLight_MulticastLock");
@@ -40,9 +53,7 @@ public class WiflyLightActivity extends Activity {
 					NetworkInfo info = connMgr.getActiveNetworkInfo();
 					TextView debug = (TextView)findViewById(R.id.debugOutput);
 					if(null != info && info.isConnected()) {
-						long pNative = createBroadcastReceiver();
-						debug.setText("b " + String.valueOf(getNumRemotes(pNative)));
-						releaseBroadcastReceiver(pNative);
+						mRemoteCollector.run();
 					} else {
 						debug.setText("no network connection found");
 					}
@@ -50,7 +61,5 @@ public class WiflyLightActivity extends Activity {
 				}
 			}
 		});
-   
-        
     }
 }

--- a/platform.h
+++ b/platform.h
@@ -26,7 +26,6 @@
 #define false FALSE
 
 //*********************** CONFIGURATION ********************************************
-#define WIFLY_SERVER_PORT 2000 // TCP/UDP Port of Wifly device
 #define NUM_OF_LED 32
 
 #ifdef X86


### PR DESCRIPTION
Implemented BroadcastReceiver in a more dynamic way. In the previous version you would have to wait the full 10 seconds until you can continue in the client, even if the client already received broadcasts. This has changed now. As soon as a broadcast was recognized it is published either at the cli or in case of the android prototype app added to a ListView.
Next issues to be solved for the BroadcastReceiver:
- omit duplicates in the list of recognized remotes
- harmonize BroadcastReceiver for OS_ANDROID and everything else (C++11 issue)
- fix x86 simulator to use client apps with it

Nils schau dir auch zum WiflyControlCli.cpp den GitHub Kommentar zu C++11 an "Files Changed" und dann nach zum Ende von WiflyControlCli.cpp scrollen
