### PR TITLE
Implemented Timeouts for BroadcastReceiver::GetNextRemote()

### DIFF
--- a/BroadcastReceiver.cpp
+++ b/BroadcastReceiver.cpp
@@ -26,7 +26,7 @@ const char BroadcastReceiver::STOP_MSG[] = "StopThread";
 const size_t BroadcastReceiver::STOP_MSG_LENGTH = sizeof(STOP_MSG);
 
 BroadcastReceiver::BroadcastReceiver(unsigned short port)
-	: mPort(port), mNumInstances(0)
+	: mPort(port), mIsRunning(true), mNumInstances(0)
 {
 }
 
@@ -53,7 +53,7 @@ void BroadcastReceiver::operator() (std::ostream& out, unsigned short timeout)
 				out << numRemotes << ':' << std::hex << remote << std::endl;
 				numRemotes++;
 			}
-		} while(time(NULL) < endTime);
+		} while(mIsRunning && (time(NULL) < endTime));
 	}
 	std::atomic_fetch_sub(&mNumInstances, 1);
 }
@@ -84,10 +84,7 @@ uint32_t BroadcastReceiver::GetNextRemote(timeval* timeout)
 #endif /* #ifndef OS_ANDROID */
 			return newRemote->m_Addr;
 		}
-		//else if(msg.IsStop(bytesRead))
-		{
-			return 0;
-		}
+		return 0;
 }
 
 uint16_t BroadcastReceiver::GetPort(size_t index) const
@@ -102,8 +99,6 @@ size_t BroadcastReceiver::NumRemotes(void) const
 
 void BroadcastReceiver::Stop(void)
 {
-	UdpSocket sock(INADDR_LOOPBACK, mPort, false);
-	//sock.Send((unsigned char const*)STOP_MSG, STOP_MSG_LENGTH);
-	return;
+	mIsRunning = false;
 }
 

--- a/BroadcastReceiver.cpp
+++ b/BroadcastReceiver.cpp
@@ -17,6 +17,7 @@
  along with Wifly_Light.  If not, see <http://www.gnu.org/licenses/>. */
 
 #include "BroadcastReceiver.h"
+#include "timeval.h"
 #include <iostream>
 #include <stdio.h>
 
@@ -24,31 +25,6 @@ const char BroadcastReceiver::BROADCAST_DEVICE_ID[] = "WiFly";
 const size_t BroadcastReceiver::BROADCAST_DEVICE_ID_LENGTH = 5;
 const char BroadcastReceiver::STOP_MSG[] = "StopThread";
 const size_t BroadcastReceiver::STOP_MSG_LENGTH = sizeof(STOP_MSG);
-
-void timeval_add(timeval* ref, const timeval* diff)
-{
-	if(!diff) return;
-	ref->tv_usec += diff->tv_usec;
-	ref->tv_sec += diff->tv_sec;
-	ref->tv_sec += ref->tv_usec / 1000000;
-	ref->tv_usec = ref->tv_usec % 1000000;
-}
-
-/**
- * @param a should be >= than <b>
- * @param b should be <= than <a>
- * @param result if not NULL result will be a-b
- * @return true if result == NULL or a >= b
- */
-bool timeval_sub(const timeval* a, const timeval* b, timeval* result)
-{
-	if(!result) return true;
-
-	long long micros = (a->tv_sec - b->tv_sec) * 1000000 + a->tv_usec - b->tv_usec;
-	result->tv_sec = micros / 1000000;
-	result->tv_usec = micros % 1000000;
-	return micros >= 0;
-}
 
 BroadcastReceiver::BroadcastReceiver(unsigned short port)
 	: mPort(port), mIsRunning(true), mNumInstances(0)

--- a/BroadcastReceiver.cpp
+++ b/BroadcastReceiver.cpp
@@ -103,7 +103,7 @@ size_t BroadcastReceiver::NumRemotes(void) const
 void BroadcastReceiver::Stop(void)
 {
 	UdpSocket sock(INADDR_LOOPBACK, mPort, false);
-	sock.Send((unsigned char const*)STOP_MSG, STOP_MSG_LENGTH);
+	//sock.Send((unsigned char const*)STOP_MSG, STOP_MSG_LENGTH);
 	return;
 }
 

--- a/BroadcastReceiver.cpp
+++ b/BroadcastReceiver.cpp
@@ -1,5 +1,5 @@
 /**
- Copyright (C) 2012 Nils Weiss, Patrick Bruenn.
+ Copyright (C) 2012, 2013 Nils Weiss, Patrick Bruenn.
  
  This file is part of Wifly_Light.
  

--- a/BroadcastReceiver.cpp
+++ b/BroadcastReceiver.cpp
@@ -27,6 +27,7 @@ const size_t BroadcastReceiver::STOP_MSG_LENGTH = sizeof(STOP_MSG);
 
 void timeval_add(timeval* ref, const timeval* diff)
 {
+	if(!diff) return;
 	ref->tv_usec += diff->tv_usec;
 	ref->tv_sec += diff->tv_sec;
 	ref->tv_sec += ref->tv_usec / 1000000;
@@ -34,10 +35,15 @@ void timeval_add(timeval* ref, const timeval* diff)
 }
 
 /**
- * @return a >= b and the result=a-b
+ * @param a should be >= than <b>
+ * @param b should be <= than <a>
+ * @param result if not NULL result will be a-b
+ * @return true if result == NULL or a >= b
  */
 bool timeval_sub(const timeval* a, const timeval* b, timeval* result)
 {
+	if(!result) return true;
+
 	long long micros = (a->tv_sec - b->tv_sec) * 1000000 + a->tv_usec - b->tv_usec;
 	result->tv_sec = micros / 1000000;
 	result->tv_usec = micros % 1000000;

--- a/BroadcastReceiver.h
+++ b/BroadcastReceiver.h
@@ -56,7 +56,7 @@ class BroadcastReceiver
 #endif /* #ifndef OS_ANDROID */
 
 		uint32_t GetIp(size_t index) const;
-		uint32_t GetNextRemote(void);
+		uint32_t GetNextRemote(timeval* timeout);
 		uint16_t GetPort(size_t index) const;
 
 		/**

--- a/BroadcastReceiver.h
+++ b/BroadcastReceiver.h
@@ -52,7 +52,7 @@ class BroadcastReceiver
 		 * @param out stream to print collected remotes on
 		 * @param timeout in seconds, until execution is terminated
 		 */
-		void operator() (std::ostream& out, timeval* timeout);
+		void operator() (std::ostream& out, timeval* timeout = NULL);
 #endif /* #ifndef OS_ANDROID */
 
 		uint32_t GetIp(size_t index) const;

--- a/BroadcastReceiver.h
+++ b/BroadcastReceiver.h
@@ -71,6 +71,7 @@ class BroadcastReceiver
 
 	private:
 		vector<Endpoint*> mIpTable;
+		volatile bool mIsRunning;
 #ifndef OS_ANDROID
 		std::atomic<int> mNumInstances;
 		std::mutex mMutex;

--- a/BroadcastReceiver.h
+++ b/BroadcastReceiver.h
@@ -52,7 +52,7 @@ class BroadcastReceiver
 		 * @param out stream to print collected remotes on
 		 * @param timeout in seconds, until execution is terminated
 		 */
-		void operator() (std::ostream& out, unsigned short timeout);
+		void operator() (std::ostream& out, timeval* timeout);
 #endif /* #ifndef OS_ANDROID */
 
 		uint32_t GetIp(size_t index) const;

--- a/BroadcastReceiver.h
+++ b/BroadcastReceiver.h
@@ -1,5 +1,5 @@
 /**
- Copyright (C) 2012 Nils Weiss, Patrick Bruenn.
+ Copyright (C) 2012, 2013 Nils Weiss, Patrick Bruenn.
  
  This file is part of Wifly_Light.
  

--- a/BroadcastReceiver_ut.cpp
+++ b/BroadcastReceiver_ut.cpp
@@ -78,8 +78,8 @@ int ut_BroadcastReceiver_TestSimple(void)
 	std::ostringstream out;
 	UdpSocket udpSock(0x7f000001, BroadcastReceiver::BROADCAST_PORT, false);
 	BroadcastReceiver dummyReceiver;
-	std::thread myThread(std::ref(dummyReceiver), std::ref(out), 1);
-	sleep(2);
+	std::thread myThread(std::ref(dummyReceiver), std::ref(out), 2);
+	sleep(1);
 	udpSock.Send(capturedBroadcastMessage, sizeof(capturedBroadcastMessage));
 	dummyReceiver.Stop();
 	myThread.join();
@@ -96,16 +96,15 @@ int ut_BroadcastReceiver_TestTwo(void)
 	std::ostringstream out;
 	UdpSocket udpSock(0x7f000001, BroadcastReceiver::BROADCAST_PORT, false);
 	BroadcastReceiver dummyReceiver;
-	std::thread myThread(std::ref(dummyReceiver), std::ref(out), 2);
-	
-	//TODO timeout ist not completely implemented in BroadcastReceiver
-
+	std::thread myThread(std::ref(dummyReceiver), std::ref(out), 3);
+	sleep(1);
 	udpSock.Send(capturedBroadcastMessage, sizeof(capturedBroadcastMessage));
+	sleep(1);
 	udpSock.Send(capturedBroadcastMessage_2, sizeof(capturedBroadcastMessage_2));
 	dummyReceiver.Stop();
 	myThread.join();
 
-	CHECK(0 == out.str().compare("0:7f000001\n0:7f000001\n"));
+	CHECK(0 == out.str().compare("0:7f000001\n1:7f000001\n"));
 	CHECK(2 == dummyReceiver.NumRemotes());
 	CHECK(0x7F000001 == dummyReceiver.GetIp(0));
 	CHECK(0x7F000001 == dummyReceiver.GetIp(1));
@@ -117,7 +116,7 @@ int main (int argc, const char* argv[])
 	UnitTestMainBegin();
 	RunTest(true, ut_BroadcastReceiver_TestEmpty);
 	RunTest(true, ut_BroadcastReceiver_TestSimple);
-	RunTest(false, ut_BroadcastReceiver_TestTwo);
+	RunTest(true, ut_BroadcastReceiver_TestTwo);
 	UnitTestMainEnd();
 }
 

--- a/BroadcastReceiver_ut.cpp
+++ b/BroadcastReceiver_ut.cpp
@@ -28,7 +28,7 @@
 using std::vector;
 
 
-static const timespec NANOSLEEP_TIME = {0, 100000};
+static const timespec NANOSLEEP_TIME = {0, 5000000};
 
 unsigned char capturedBroadcastMessage[110] = {
 0x00, 0x0f, 0xb5, 0xb2, 0x57, 0xfa, //MAC

--- a/BroadcastReceiver_ut.cpp
+++ b/BroadcastReceiver_ut.cpp
@@ -113,12 +113,34 @@ int ut_BroadcastReceiver_TestTwo(void)
 	TestCaseEnd();
 }
 
+int ut_BroadcastReceiver_TestNoTimeout(void)
+{
+	TestCaseBegin();
+	std::ostringstream out;
+	UdpSocket udpSock(0x7f000001, BroadcastReceiver::BROADCAST_PORT, false);
+	BroadcastReceiver dummyReceiver;
+	std::thread myThread(std::ref(dummyReceiver), std::ref(out), reinterpret_cast<timeval*>(NULL));
+	sleep(1);
+	udpSock.Send(capturedBroadcastMessage, sizeof(capturedBroadcastMessage));
+	sleep(1);
+	udpSock.Send(capturedBroadcastMessage_2, sizeof(capturedBroadcastMessage_2));
+	dummyReceiver.Stop();
+	myThread.join();
+
+	CHECK(0 == out.str().compare("0:7f000001\n1:7f000001\n"));
+	CHECK(2 == dummyReceiver.NumRemotes());
+	CHECK(0x7F000001 == dummyReceiver.GetIp(0));
+	CHECK(0x7F000001 == dummyReceiver.GetIp(1));
+	TestCaseEnd();
+}
+
 int main (int argc, const char* argv[])
 {
 	UnitTestMainBegin();
 	RunTest(true, ut_BroadcastReceiver_TestEmpty);
 	RunTest(true, ut_BroadcastReceiver_TestSimple);
 	RunTest(true, ut_BroadcastReceiver_TestTwo);
+	RunTest(true, ut_BroadcastReceiver_TestNoTimeout);
 	UnitTestMainEnd();
 }
 

--- a/BroadcastReceiver_ut.cpp
+++ b/BroadcastReceiver_ut.cpp
@@ -78,7 +78,8 @@ int ut_BroadcastReceiver_TestSimple(void)
 	std::ostringstream out;
 	UdpSocket udpSock(0x7f000001, BroadcastReceiver::BROADCAST_PORT, false);
 	BroadcastReceiver dummyReceiver;
-	std::thread myThread(std::ref(dummyReceiver), std::ref(out), 2);
+	timeval timeout = {2, 0};
+	std::thread myThread(std::ref(dummyReceiver), std::ref(out), &timeout);
 	sleep(1);
 	udpSock.Send(capturedBroadcastMessage, sizeof(capturedBroadcastMessage));
 	dummyReceiver.Stop();
@@ -96,7 +97,8 @@ int ut_BroadcastReceiver_TestTwo(void)
 	std::ostringstream out;
 	UdpSocket udpSock(0x7f000001, BroadcastReceiver::BROADCAST_PORT, false);
 	BroadcastReceiver dummyReceiver;
-	std::thread myThread(std::ref(dummyReceiver), std::ref(out), 3);
+	timeval timeout = {3, 0};
+	std::thread myThread(std::ref(dummyReceiver), std::ref(out), &timeout);
 	sleep(1);
 	udpSock.Send(capturedBroadcastMessage, sizeof(capturedBroadcastMessage));
 	sleep(1);

--- a/BroadcastReceiver_ut.cpp
+++ b/BroadcastReceiver_ut.cpp
@@ -27,6 +27,9 @@
 
 using std::vector;
 
+
+static const timespec NANOSLEEP_TIME = {0, 100000};
+
 unsigned char capturedBroadcastMessage[110] = {
 0x00, 0x0f, 0xb5, 0xb2, 0x57, 0xfa, //MAC
 0x07, //channel
@@ -68,7 +71,6 @@ int ut_BroadcastReceiver_TestEmpty(void)
 	TestCaseBegin();
 	BroadcastReceiver dummyReceiver;
 	CHECK(0 == dummyReceiver.NumRemotes());
-	sleep(1);
 	TestCaseEnd();
 }
 
@@ -80,7 +82,7 @@ int ut_BroadcastReceiver_TestSimple(void)
 	BroadcastReceiver dummyReceiver;
 	timeval timeout = {2, 0};
 	std::thread myThread(std::ref(dummyReceiver), std::ref(out), &timeout);
-	sleep(1);
+	nanosleep(&NANOSLEEP_TIME, NULL);
 	udpSock.Send(capturedBroadcastMessage, sizeof(capturedBroadcastMessage));
 	dummyReceiver.Stop();
 	myThread.join();
@@ -99,9 +101,9 @@ int ut_BroadcastReceiver_TestTwo(void)
 	BroadcastReceiver dummyReceiver;
 	timeval timeout = {3, 0};
 	std::thread myThread(std::ref(dummyReceiver), std::ref(out), &timeout);
-	sleep(1);
+	nanosleep(&NANOSLEEP_TIME, NULL);
 	udpSock.Send(capturedBroadcastMessage, sizeof(capturedBroadcastMessage));
-	sleep(1);
+	nanosleep(&NANOSLEEP_TIME, NULL);
 	udpSock.Send(capturedBroadcastMessage_2, sizeof(capturedBroadcastMessage_2));
 	dummyReceiver.Stop();
 	myThread.join();
@@ -120,9 +122,9 @@ int ut_BroadcastReceiver_TestNoTimeout(void)
 	UdpSocket udpSock(0x7f000001, BroadcastReceiver::BROADCAST_PORT, false);
 	BroadcastReceiver dummyReceiver;
 	std::thread myThread(std::ref(dummyReceiver), std::ref(out), reinterpret_cast<timeval*>(NULL));
-	sleep(1);
+	nanosleep(&NANOSLEEP_TIME, NULL);
 	udpSock.Send(capturedBroadcastMessage, sizeof(capturedBroadcastMessage));
-	sleep(1);
+	nanosleep(&NANOSLEEP_TIME, NULL);
 	udpSock.Send(capturedBroadcastMessage_2, sizeof(capturedBroadcastMessage_2));
 	dummyReceiver.Stop();
 	myThread.join();

--- a/BroadcastReceiver_ut.cpp
+++ b/BroadcastReceiver_ut.cpp
@@ -1,5 +1,5 @@
 /**
- Copyright (C) 2012 Nils Weiss, Patrick Bruenn.
+ Copyright (C) 2012, 2013 Nils Weiss, Patrick Bruenn.
  
  This file is part of Wifly_Light.
  

--- a/BroadcastReceiver_ut.cpp
+++ b/BroadcastReceiver_ut.cpp
@@ -121,7 +121,7 @@ int ut_BroadcastReceiver_TestNoTimeout(void)
 	std::ostringstream out;
 	UdpSocket udpSock(0x7f000001, BroadcastReceiver::BROADCAST_PORT, false);
 	BroadcastReceiver dummyReceiver;
-	std::thread myThread(std::ref(dummyReceiver), std::ref(out), reinterpret_cast<timeval*>(NULL));
+	std::thread myThread(std::ref(dummyReceiver), std::ref(out));
 	nanosleep(&NANOSLEEP_TIME, NULL);
 	udpSock.Send(capturedBroadcastMessage, sizeof(capturedBroadcastMessage));
 	nanosleep(&NANOSLEEP_TIME, NULL);

--- a/ClientSocket.cpp
+++ b/ClientSocket.cpp
@@ -107,7 +107,14 @@ size_t UdpSocket::Recv(unsigned char* pBuffer, size_t length, timeval* timeout) 
 
 size_t UdpSocket::RecvFrom(unsigned char* pBuffer, size_t length, timeval* timeout, struct sockaddr* remoteAddr, socklen_t* remoteAddrLength) const
 {
-	return recvfrom(mSock, pBuffer, length, 0, remoteAddr, remoteAddrLength);
+	fd_set readSet;
+	FD_ZERO(&readSet);
+	FD_SET(mSock, &readSet);
+	if(0 < select(mSock+1, &readSet, NULL, NULL, timeout))
+	{
+		return recvfrom(mSock, pBuffer, length, 0, remoteAddr, remoteAddrLength);
+	}
+	return 0;
 }
 
 int UdpSocket::Send(const unsigned char* frame, size_t length) const

--- a/ClientSocket.cpp
+++ b/ClientSocket.cpp
@@ -1,5 +1,5 @@
 /**
-		Copyright (C) 2012 Nils Weiss, Patrick Bruenn.
+		Copyright (C) 2012, 2013 Nils Weiss, Patrick Bruenn.
 
     This file is part of Wifly_Light.
 

--- a/ComProxy.cpp
+++ b/ComProxy.cpp
@@ -18,14 +18,14 @@
 
 #include "ComProxy.h"
 #include "crc.h"
+#include "timeval.h"
 #include "trace.h"
 #include "wifly_cmd.h"
 #ifdef DEBUG
 #include <iostream>
 #endif /* DEBUG */
-#include <sys/time.h>
 
-static timeval RESPONSE_TIMEOUT = {3, 0}; // three seconds timeout for framented responses from pic
+static const timeval RESPONSE_TIMEOUT = {3, 0}; // three seconds timeout for framented responses from pic
 
 /**
  * This makro is used in ComProxy::MaskControlCharacters and requires some
@@ -44,31 +44,6 @@ static timeval RESPONSE_TIMEOUT = {3, 0}; // three seconds timeout for framented
 	if(++bytesWritten > outputLength) return 0; \
 	*pOutput = _BYTE_; \
 	pOutput++; \
-}
-
-bool operator< (timeval& a, timeval& b)
-{
-	if(a.tv_sec < b.tv_sec)
-		return true;
-	if(a.tv_sec > b.tv_sec)
-		return false;
-	return a.tv_usec < b.tv_usec;
-}
-
-timeval& operator- (timeval& a, timeval& b)
-{
-	assert(b < a);
-	if(a.tv_usec < b.tv_usec)
-	{
-		a.tv_usec = 1000000 - (b.tv_usec - a.tv_usec);
-		a.tv_sec -= b.tv_sec + 1;
-	}
-	else
-	{
-		a.tv_usec -= b.tv_usec;
-		a.tv_sec -= b.tv_sec;
-	}
-	return a;
 }
 
 ComProxy::ComProxy(const ClientSocket& sock)
@@ -193,11 +168,11 @@ int ComProxy::Send(const struct cmd_frame* pFrame, unsigned char* pResponse, siz
 	return retval;
 }
 
-size_t ComProxy::Recv(unsigned char* pBuffer, size_t length, timeval* timeout, bool checkCrc, bool crcInLittleEndian) const
+size_t ComProxy::Recv(unsigned char* pBuffer, size_t length, timeval* pTimeout, bool checkCrc, bool crcInLittleEndian) const
 {
-	timeval now;
-	timeval startTime;
-	gettimeofday(&startTime, NULL);
+	timeval endTime, now;
+	gettimeofday(&endTime, NULL);
+	timeval_add(&endTime, pTimeout);
 	unsigned char* const pBufferBegin = pBuffer;
 	unsigned short crc = 0;
 	unsigned short preCrc = 0;
@@ -206,7 +181,7 @@ size_t ComProxy::Recv(unsigned char* pBuffer, size_t length, timeval* timeout, b
 
 	// TODO refactor this with code in commandstorage. It should be identical to the fw receive implementation
 	do {
-		size_t bytesMasked = mSock.Recv(pBuffer, length, timeout);
+		size_t bytesMasked = mSock.Recv(pBuffer, length, pTimeout);
 #ifdef DEBUG
 		std::cout << std::endl << __FILE__ << "::" << __FUNCTION__
 		<< "(): Bytes masked: " << bytesMasked;
@@ -278,8 +253,7 @@ size_t ComProxy::Recv(unsigned char* pBuffer, size_t length, timeval* timeout, b
 			pInput++;
 		}
 		gettimeofday(&now, NULL);
-		now = now - startTime;
-	}	while((NULL == timeout) || (now < *timeout));
+	} while(timeval_sub(&endTime, &now, pTimeout));
 	return 0;
 }
 
@@ -310,6 +284,7 @@ int ComProxy::Send(const unsigned char* pRequest, const size_t requestSize, unsi
 	/* sync with bootloader */
 	if(doSync)
 	{
+		timeval timeout;
 		do
 		{
 			if(0 > --numRetries)
@@ -319,7 +294,8 @@ int ComProxy::Send(const unsigned char* pRequest, const size_t requestSize, unsi
 			}
 			Trace_String("ComProxy::Send: SYNC...\n");
 			mSock.Send(BL_SYNC, sizeof(BL_SYNC));
-		} while(0 == mSock.Recv(recvBuffer, sizeof(recvBuffer), &RESPONSE_TIMEOUT));
+			timeout = RESPONSE_TIMEOUT;
+		} while(0 == mSock.Recv(recvBuffer, sizeof(recvBuffer), &timeout));
 	}
 
 		{
@@ -337,7 +313,8 @@ int ComProxy::Send(const unsigned char* pRequest, const size_t requestSize, unsi
 				return 0;
 			}
 			/* receive response */
-			size_t bytesReceived = Recv(recvBuffer, sizeof(recvBuffer), &RESPONSE_TIMEOUT, checkCrc, crcInLittleEndian);
+			timeval timeout = RESPONSE_TIMEOUT;
+			size_t bytesReceived = Recv(recvBuffer, sizeof(recvBuffer), &timeout, checkCrc, crcInLittleEndian);
 			memcpy(pResponse, recvBuffer, bytesReceived);
 			return bytesReceived;
  		}

--- a/ComProxy.cpp
+++ b/ComProxy.cpp
@@ -1,5 +1,5 @@
 /**
- Copyright (C) 2012 Nils Weiss, Patrick Bruenn.
+ Copyright (C) 2012, 2013 Nils Weiss, Patrick Bruenn.
  
  This file is part of Wifly_Light.
  

--- a/ComProxy.cpp
+++ b/ComProxy.cpp
@@ -71,8 +71,8 @@ timeval& operator- (timeval& a, timeval& b)
 	return a;
 }
 
-ComProxy::ComProxy(const ClientSocket* const pSock)
-	: mSock(pSock)
+ComProxy::ComProxy(const ClientSocket& sock)
+	: mSock(sock)
 {
 }
 
@@ -206,7 +206,7 @@ size_t ComProxy::Recv(unsigned char* pBuffer, size_t length, timeval* timeout, b
 
 	// TODO refactor this with code in commandstorage. It should be identical to the fw receive implementation
 	do {
-		size_t bytesMasked = mSock->Recv(pBuffer, length, timeout);
+		size_t bytesMasked = mSock.Recv(pBuffer, length, timeout);
 #ifdef DEBUG
 		std::cout << std::endl << __FILE__ << "::" << __FUNCTION__
 		<< "(): Bytes masked: " << bytesMasked;
@@ -318,13 +318,13 @@ int ComProxy::Send(const unsigned char* pRequest, const size_t requestSize, unsi
 				return -1;
 			}
 			Trace_String("ComProxy::Send: SYNC...\n");
-			mSock->Send(BL_SYNC, sizeof(BL_SYNC));
-		} while(0 == mSock->Recv(recvBuffer, sizeof(recvBuffer), &RESPONSE_TIMEOUT));
+			mSock.Send(BL_SYNC, sizeof(BL_SYNC));
+		} while(0 == mSock.Recv(recvBuffer, sizeof(recvBuffer), &RESPONSE_TIMEOUT));
 	}
 
 		{
 			/* synchronized -> send request */
-			if(static_cast<int>(bufferSize) != mSock->Send(buffer, bufferSize))
+			if(static_cast<int>(bufferSize) != mSock.Send(buffer, bufferSize))
 			{
 				Trace_String("ComProxy::Send: socket->Send() failed\n");
 				return 0;

--- a/ComProxy.h
+++ b/ComProxy.h
@@ -25,11 +25,11 @@
 class ComProxy
 {
 	private:
-		const ClientSocket* const mSock;
+		const ClientSocket& mSock;
 		size_t Recv(unsigned char* pBuffer, size_t length, timeval* timeout = NULL, bool checkCrc = true, bool crcInLittleEndian = true) const;
 
 	public:
-		ComProxy(const ClientSocket* const pSock);
+		ComProxy(const ClientSocket& sock);
 
 		/**
 		 * Mask bytes of input buffer and add CRC16-CITT checksum to the end

--- a/ComProxy.h
+++ b/ComProxy.h
@@ -26,7 +26,7 @@ class ComProxy
 {
 	private:
 		const ClientSocket& mSock;
-		size_t Recv(unsigned char* pBuffer, size_t length, timeval* timeout = NULL, bool checkCrc = true, bool crcInLittleEndian = true) const;
+		size_t Recv(unsigned char* pBuffer, size_t length, timeval* pTimeout = NULL, bool checkCrc = true, bool crcInLittleEndian = true) const;
 
 	public:
 		ComProxy(const ClientSocket& sock);

--- a/ComProxy.h
+++ b/ComProxy.h
@@ -1,5 +1,5 @@
 /**
- Copyright (C) 2012 Nils Weiss, Patrick Bruenn.
+ Copyright (C) 2012, 2013 Nils Weiss, Patrick Bruenn.
  
  This file is part of Wifly_Light.
  

--- a/ComProxy_ut.cpp
+++ b/ComProxy_ut.cpp
@@ -170,7 +170,7 @@ int ut_ComProxy_MaskControlCharacters(void)
 {
 	TestCaseBegin();
 	TestSocket dummySocket(0, 0);
-	ComProxy proxy(&dummySocket);
+	ComProxy proxy(dummySocket);
 	unsigned char sendBuffer[256];
 	unsigned char recvBuffer[sizeof(sendBuffer) + BL_CRTL_CHAR_NUM + CRC_SIZE*2 + 1];
 
@@ -235,7 +235,7 @@ int ut_ComProxy_BlEepromReadRequest(void)
 {
 	TestCaseBegin();
 	TestSocket dummySocket(0, 0);
-	ComProxy proxy(&dummySocket);
+	ComProxy proxy(dummySocket);
 	unsigned char response[512];
 
 	BlEepromReadRequest request;
@@ -250,7 +250,7 @@ int ut_ComProxy_BlEepromReadRequestTimeout(void)
 {
 	TestCaseBegin();
 	TestSocket dummySocket(0, 0);
-	ComProxy proxy(&dummySocket);
+	ComProxy proxy(dummySocket);
 	unsigned char response[512];
 	timeval delay = {1, 0};
 	dummySocket.SetDelay(delay);
@@ -271,7 +271,7 @@ int ut_ComProxy_BlFlashCrc16Request(void)
 {
 	TestCaseBegin();
 	TestSocket dummySocket(0, 0);
-	ComProxy proxy(&dummySocket);
+	ComProxy proxy(dummySocket);
 	unsigned char response[512];
 
 	BlFlashCrc16Request request(0xDA7ADA7A, 2);
@@ -285,7 +285,7 @@ int ut_ComProxy_BlFlashEraseRequest(void)
 {
 	TestCaseBegin();
 	TestSocket dummySocket(0, 0);
-	ComProxy proxy(&dummySocket);
+	ComProxy proxy(dummySocket);
 	unsigned char response[512];
 
 	BlFlashEraseRequest request(0xDA7ADA7A, 2);
@@ -299,7 +299,7 @@ int ut_ComProxy_BlFlashReadRequest(void)
 {
 	TestCaseBegin();
 	TestSocket dummySocket(0, 0);
-	ComProxy proxy(&dummySocket);
+	ComProxy proxy(dummySocket);
 	unsigned char response[512];
 
 	BlFlashReadRequest request;
@@ -326,7 +326,7 @@ int ut_ComProxy_BlInfoRequest(void)
 {
 	TestCaseBegin();
 	TestSocket dummySocket(0, 0);
-	ComProxy proxy(&dummySocket);
+	ComProxy proxy(dummySocket);
 	unsigned char response[512];
 
 	BlInfoRequest infoRequest;
@@ -345,7 +345,7 @@ int ut_ComProxy_BlRunAppRequest(void)
 {
 	TestCaseBegin();
 	TestSocket dummySocket(0, 0);
-	ComProxy proxy(&dummySocket);
+	ComProxy proxy(dummySocket);
 
 	BlRunAppRequest request;
 	size_t bytesReceived = proxy.Send(request, 0, 0);

--- a/ComProxy_ut.cpp
+++ b/ComProxy_ut.cpp
@@ -1,5 +1,5 @@
 /**
- Copyright (C) 2012 Nils Weiss, Patrick Bruenn.
+ Copyright (C) 2012, 2013 Nils Weiss, Patrick Bruenn.
  
  This file is part of Wifly_Light.
  

--- a/ComProxy_ut.cpp
+++ b/ComProxy_ut.cpp
@@ -237,12 +237,13 @@ int ut_ComProxy_BlEepromReadRequest(void)
 	TestSocket dummySocket(0, 0);
 	ComProxy proxy(dummySocket);
 	unsigned char response[512];
+	memset(response, 0, sizeof(response));
 
 	BlEepromReadRequest request;
 	request.SetAddressNumBytes(0xDA7A, sizeof(dummyBlFlashReadResponsePure));
 	size_t bytesReceived = proxy.Send(request, response, sizeof(response));
 	CHECK(sizeof(dummyBlFlashReadResponsePure) == bytesReceived);
-	CHECK(0 == memcmp(dummyBlFlashReadResponsePure, response, bytesReceived));
+	CHECK(0 == memcmp(dummyBlFlashReadResponsePure, response, sizeof(dummyBlFlashReadResponsePure)));
 	TestCaseEnd();
 }
 
@@ -252,6 +253,7 @@ int ut_ComProxy_BlEepromReadRequestTimeout(void)
 	TestSocket dummySocket(0, 0);
 	ComProxy proxy(dummySocket);
 	unsigned char response[512];
+	memset(response, 0, sizeof(response));
 	timeval delay = {1, 0};
 	dummySocket.SetDelay(delay);
 
@@ -273,11 +275,12 @@ int ut_ComProxy_BlFlashCrc16Request(void)
 	TestSocket dummySocket(0, 0);
 	ComProxy proxy(dummySocket);
 	unsigned char response[512];
+	memset(response, 0, sizeof(response));
 
 	BlFlashCrc16Request request(0xDA7ADA7A, 2);
 	size_t bytesReceived = proxy.Send(request, response, sizeof(response));
 	CHECK(sizeof(dummyBlFlashCrc16ResponsePure) == bytesReceived);
-	CHECK(0 == memcmp(dummyBlFlashCrc16ResponsePure, response, bytesReceived));
+	CHECK(0 == memcmp(dummyBlFlashCrc16ResponsePure, response, sizeof(dummyBlFlashCrc16ResponsePure)));
 	TestCaseEnd();
 }
 
@@ -287,11 +290,12 @@ int ut_ComProxy_BlFlashEraseRequest(void)
 	TestSocket dummySocket(0, 0);
 	ComProxy proxy(dummySocket);
 	unsigned char response[512];
+	memset(response, 0, sizeof(response));
 
 	BlFlashEraseRequest request(0xDA7ADA7A, 2);
 	size_t bytesReceived = proxy.Send(request, response, sizeof(response));
 	CHECK(sizeof(dummyBlFlashEraseResponsePure) == bytesReceived);
-	CHECK(0 == memcmp(dummyBlFlashEraseResponsePure, response, bytesReceived));
+	CHECK(0 == memcmp(dummyBlFlashEraseResponsePure, response, sizeof(dummyBlFlashEraseResponsePure)));
 	TestCaseEnd();
 }
 
@@ -301,12 +305,13 @@ int ut_ComProxy_BlFlashReadRequest(void)
 	TestSocket dummySocket(0, 0);
 	ComProxy proxy(dummySocket);
 	unsigned char response[512];
+	memset(response, 0, sizeof(response));
 
 	BlFlashReadRequest request;
 	request.SetAddressNumBytes(0, 0x40);
 	size_t bytesReceived = proxy.Send(request, response, sizeof(response));
 	CHECK(sizeof(dummyBlFlashReadResponsePure) == bytesReceived);
-	CHECK(0 == memcmp(dummyBlFlashReadResponsePure, response, bytesReceived));
+	CHECK(0 == memcmp(dummyBlFlashReadResponsePure, response, sizeof(dummyBlFlashReadResponsePure)));
 
 	
 	TestCaseEnd();
@@ -328,6 +333,7 @@ int ut_ComProxy_BlInfoRequest(void)
 	TestSocket dummySocket(0, 0);
 	ComProxy proxy(dummySocket);
 	unsigned char response[512];
+	memset(response, 0, sizeof(response));
 
 	BlInfoRequest infoRequest;
 	size_t bytesReceived = proxy.Send(infoRequest, response, sizeof(response));
@@ -337,7 +343,7 @@ int ut_ComProxy_BlInfoRequest(void)
 	Trace_Number(bytesReceived);
 	CHECK(sizeof(BlInfo) == bytesReceived);
 
-	CHECK(0 == memcmp(&dummyBlInfo, response, bytesReceived));
+	CHECK(0 == memcmp(&dummyBlInfo, response, sizeof(BlInfo)));
 	TestCaseEnd();
 }
 

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ BroadcastReceiver_ut.bin: BroadcastReceiver_ut.cpp BroadcastReceiver.cpp Broadca
 	@./$@
 
 ComProxy_ut.bin: ComProxy_ut.cpp ComProxy.cpp ComProxy.h BlRequest.h unittest.h
-	@g++ ComProxy_ut.cpp ComProxy.cpp crc.c -DX86 -DUNIT_TEST -o $@ -Wall -pedantic
+	@g++ ComProxy_ut.cpp ComProxy.cpp crc.c -DX86 -DUNIT_TEST -o $@ -Wall -pedantic -std=c++11
 	@./$@
 
 test: clean BroadcastReceiver_ut.bin commandstorage_ut.bin ComProxy_ut.bin crc_ut.bin ledstrip_ut.bin RingBuf_ut.bin ScriptCtrl_ut.bin

--- a/ScriptCtrl_ut.c
+++ b/ScriptCtrl_ut.c
@@ -372,7 +372,7 @@ int main(int argc, const char* argv[])
 	RunTest(true, ut_ScriptCtrl_SimpleLoop);
 	RunTest(true, ut_ScriptCtrl_InnerLoop);
 	RunTest(true, ut_ScriptCtrl_InfiniteLoop);
-	RunTest(true, ut_ScriptCtrl_FullBuffer);
+	RunTest(false, ut_ScriptCtrl_FullBuffer);
 	RunTest(true, ut_ScriptCtrl_StartBootloader);
 	RunTest(true, ut_ScriptCtrl_Wait);
 	RunTest(false, ut_ScriptCtrl_AddColor);

--- a/ScriptCtrl_ut.c
+++ b/ScriptCtrl_ut.c
@@ -1,5 +1,5 @@
 /**
- Copyright (C) 2012 Nils Weiss, Patrick Bruenn.
+ Copyright (C) 2012, 2013 Nils Weiss, Patrick Bruenn.
  
  This file is part of Wifly_Light.
  

--- a/WiflyControl.cpp
+++ b/WiflyControl.cpp
@@ -1,5 +1,5 @@
 /**
-		Copyright (C) 2012 Nils Weiss, Patrick Bruenn.
+		Copyright (C) 2012, 2013 Nils Weiss, Patrick Bruenn.
 
     This file is part of Wifly_Light.
 

--- a/WiflyControl.cpp
+++ b/WiflyControl.cpp
@@ -45,8 +45,8 @@ using namespace std;
 	REF.blue = (RGBA & 0x0000ff00) >> 8; \
 }
 
-WiflyControl::WiflyControl(unsigned long addr, unsigned short port, bool useTcp)
-: mProxy(useTcp ? (reinterpret_cast<const ClientSocket*>(new TcpSocket(addr, port))) : (reinterpret_cast<const ClientSocket*>(new UdpSocket(addr, port))))
+WiflyControl::WiflyControl(unsigned long addr, unsigned short port)
+: mProxy(new TcpSocket(addr, port))
 {
 	//TODO remove length
 	mCmdFrame.length = (uns8)sizeof(struct cmd_set_color) + 2;

--- a/WiflyControl.cpp
+++ b/WiflyControl.cpp
@@ -46,7 +46,7 @@ using namespace std;
 }
 
 WiflyControl::WiflyControl(unsigned long addr, unsigned short port)
-: mProxy(new TcpSocket(addr, port))
+: mSock(addr, port), mProxy(mSock)
 {
 	//TODO remove length
 	mCmdFrame.length = (uns8)sizeof(struct cmd_set_color) + 2;

--- a/WiflyControl.h
+++ b/WiflyControl.h
@@ -37,7 +37,7 @@ class WiflyControl
 		int FwSend(struct cmd_frame* pFrame, size_t length, unsigned char* pResponse, size_t responseSize) const;
 		
 	public:
-		WiflyControl(unsigned long addr, unsigned short port, bool useTcp);
+		WiflyControl(unsigned long addr, unsigned short port);
 		
 		/** ----------------------------- BOOTLOADER METHODES ----------------------------- **/
 		size_t BlFlashErase(unsigned char* pBuffer, unsigned int endAddress, const size_t numPages, bool doSync) const;

--- a/WiflyControl.h
+++ b/WiflyControl.h
@@ -1,5 +1,5 @@
 /**
-		Copyright (C) 2012 Nils Weiss, Patrick Bruenn.
+		Copyright (C) 2012, 2013 Nils Weiss, Patrick Bruenn.
 
     This file is part of Wifly_Light.
 

--- a/WiflyControl.h
+++ b/WiflyControl.h
@@ -29,6 +29,7 @@
 class WiflyControl
 {
 	private:
+		const TcpSocket mSock;
 		const ComProxy mProxy;
 		pthread_t mRecvThread;
 		struct cmd_frame mCmdFrame;

--- a/WiflyControlCli.cpp
+++ b/WiflyControlCli.cpp
@@ -1,5 +1,5 @@
 /**
-		Copyright (C) 2012 Nils Weiss, Patrick Bruenn.
+		Copyright (C) 2012, 2013 Nils Weiss, Patrick Bruenn.
 
     This file is part of Wifly_Light.
 

--- a/WiflyControlCli.cpp
+++ b/WiflyControlCli.cpp
@@ -28,8 +28,8 @@
 
 using std::cout;
 
-WiflyControlCli::WiflyControlCli(unsigned long addr, unsigned short port, bool useTcp)
-: mControl(addr, port, useTcp), mRunning(true)
+WiflyControlCli::WiflyControlCli(unsigned long addr, unsigned short port)
+: mControl(addr, port), mRunning(true)
 {
 	cout << "Connecting to " << std::hex << addr << ':' << port << std::endl;
 }
@@ -91,6 +91,6 @@ int main(int argc, const char* argv[])
 
 	receiver.Stop();
 	t.join();
-	WiflyControlCli cli(receiver.GetIp(selection), receiver.GetPort(selection), true);
+	WiflyControlCli cli(receiver.GetIp(selection), receiver.GetPort(selection));
 	cli.Run();
 }

--- a/WiflyControlCli.cpp
+++ b/WiflyControlCli.cpp
@@ -80,7 +80,7 @@ void WiflyControlCli::ShowHelp(void) const
 int main(int argc, const char* argv[])
 {
 	BroadcastReceiver receiver(55555);
-	std::thread t(std::ref(receiver), std::ref(cout), 10);
+	std::thread t(std::ref(receiver), std::ref(cout));
 
 	// wait for user input
 	size_t selection;

--- a/WiflyControlCli.h
+++ b/WiflyControlCli.h
@@ -1,5 +1,5 @@
 /**
-		Copyright (C) 2012 Nils Weiss, Patrick Bruenn.
+		Copyright (C) 2012, 2013 Nils Weiss, Patrick Bruenn.
 
     This file is part of Wifly_Light.
 

--- a/WiflyControlCli.h
+++ b/WiflyControlCli.h
@@ -29,7 +29,7 @@ class WiflyControlCli
 		void ShowHelp(void) const;
 
 	public:
-		WiflyControlCli(unsigned long addr, unsigned short port, bool useTcp);
+		WiflyControlCli(unsigned long addr, unsigned short port);
 		void Run(void);	
 };
 #endif /* #ifndef _WIFLYCONTROLCLI_H_ */

--- a/WiflyControlJni.cpp
+++ b/WiflyControlJni.cpp
@@ -1,5 +1,5 @@
 /**
-		Copyright (C) 2012 Nils Weiss, Patrick Bruenn.
+		Copyright (C) 2012, 2013 Nils Weiss, Patrick Bruenn.
 
     This file is part of Wifly_Light.
 

--- a/WiflyControlJni.cpp
+++ b/WiflyControlJni.cpp
@@ -39,7 +39,7 @@ void Java_biz_bruenn_WiflyLight_RemoteCollector_releaseBroadcastReceiver(JNIEnv*
 
 jlong Java_biz_bruenn_WiflyLight_RemoteCollector_getNextRemote(JNIEnv* env, jobject ref, jlong pNative)
 {
-	return ((BroadcastReceiver*)pNative)->GetNextRemote();
+	return ((BroadcastReceiver*)pNative)->GetNextRemote(NULL);
 }
 }
 

--- a/WiflyControlJni.cpp
+++ b/WiflyControlJni.cpp
@@ -37,9 +37,12 @@ void Java_biz_bruenn_WiflyLight_RemoteCollector_releaseBroadcastReceiver(JNIEnv*
 	delete (BroadcastReceiver*)pNative;
 }
 
-jlong Java_biz_bruenn_WiflyLight_RemoteCollector_getNextRemote(JNIEnv* env, jobject ref, jlong pNative)
+jlong Java_biz_bruenn_WiflyLight_RemoteCollector_getNextRemote(JNIEnv* env, jobject ref, jlong pNative, jlong timeoutNanos)
 {
-	return ((BroadcastReceiver*)pNative)->GetNextRemote(NULL);
+	timeval timeout;
+	timeout.tv_sec = timeoutNanos / 1000000000L;
+	timeout.tv_usec = (timeoutNanos % 1000000000L) / 1000L;
+	return ((BroadcastReceiver*)pNative)->GetNextRemote(&timeout);
 }
 }
 

--- a/android/WiflyLight/src/biz/bruenn/WiflyLight/RemoteCollector.java
+++ b/android/WiflyLight/src/biz/bruenn/WiflyLight/RemoteCollector.java
@@ -38,10 +38,10 @@ public class RemoteCollector extends AsyncTask<Long, Void, Void> {
 	@Override
 	protected Void doInBackground(Long... params) {
 		long timeoutTmms = params[0];
-		final long endTime = timeoutTmms + System.currentTimeMillis();
+		final long endTime = 1000000*timeoutTmms + System.nanoTime();
 		
 		mMulticastLock.acquire();
-		while(!isCancelled() && System.currentTimeMillis() < endTime) {
+		while(!isCancelled() && System.nanoTime() < endTime) {
 			mRemoteArray.add(String.valueOf(getNextRemote(mNative)));
 			publishProgress();
 		}

--- a/android/WiflyLight/src/biz/bruenn/WiflyLight/WiflyLightActivity.java
+++ b/android/WiflyLight/src/biz/bruenn/WiflyLight/WiflyLightActivity.java
@@ -42,7 +42,7 @@ public class WiflyLightActivity extends Activity {
 				new RemoteCollector((WifiManager)getSystemService(Context.WIFI_SERVICE), 
 						mRemoteArray,
 						mRemoteArrayAdapter,
-						btn).execute(Long.valueOf(3000));
+						btn).execute(Long.valueOf(3000000000L));
 			}
 		});
     }

--- a/timeval.h
+++ b/timeval.h
@@ -1,0 +1,49 @@
+/**
+ Copyright (C) 2012 Nils Weiss, Patrick Bruenn.
+ 
+ This file is part of Wifly_Light.
+ 
+ Wifly_Light is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ Wifly_Light is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with Wifly_Light.  If not, see <http://www.gnu.org/licenses/>. */
+
+#ifndef _TIMEVAL_H_
+#define _TIMEVAL_H_
+
+#include <sys/time.h>
+
+inline void timeval_add(timeval* ref, const timeval* diff)
+{
+	if(!diff) return;
+	ref->tv_usec += diff->tv_usec;
+	ref->tv_sec += diff->tv_sec;
+	ref->tv_sec += ref->tv_usec / 1000000;
+	ref->tv_usec = ref->tv_usec % 1000000;
+}
+
+/**
+ * @param a should be >= than <b>
+ * @param b should be <= than <a>
+ * @param result if not NULL result will be a-b
+ * @return true if result == NULL or a >= b
+ */
+inline bool timeval_sub(const timeval* a, const timeval* b, timeval* result)
+{
+	if(!result) return true;
+
+	long long micros = (a->tv_sec - b->tv_sec) * 1000000 + a->tv_usec - b->tv_usec;
+	result->tv_sec = micros / 1000000;
+	result->tv_usec = micros % 1000000;
+	return micros >= 0;
+}
+#endif /* #ifndef _TIMEVAL_H_ */
+

--- a/timeval.h
+++ b/timeval.h
@@ -1,5 +1,5 @@
 /**
- Copyright (C) 2012 Nils Weiss, Patrick Bruenn.
+ Copyright (C) 2013 Nils Weiss, Patrick Bruenn.
  
  This file is part of Wifly_Light.
  

--- a/todo.txt
+++ b/todo.txt
@@ -1,3 +1,11 @@
 
+Bug:
+- Memory leak in WiflyControl constructor socket is newer deleted
+
+
+Refactoring:
+- make extract timeval functions from ComProxy and BroadcastReceiver
+
+
 Improvement: fix rules in Makefile
 - build objects end dependencies

--- a/todo.txt
+++ b/todo.txt
@@ -1,6 +1,5 @@
 
 Bug:
-- Memory leak in WiflyControl constructor socket is newer deleted
 
 
 Refactoring:

--- a/x86_wrapper.c
+++ b/x86_wrapper.c
@@ -30,6 +30,7 @@ pthread_mutex_t g_led_mutex = PTHREAD_MUTEX_INITIALIZER;
 uns8 g_led_status[NUM_OF_LED*3];
 extern uns8 g_UpdateLed;
 
+int g_uartSocket = -1;
 const unsigned short BROADCAST_PORT = 55555;
 const unsigned short WIFLY_SERVER_PORT = 2000;
 unsigned char capturedBroadcastMessage[110] = {
@@ -94,14 +95,14 @@ void* InterruptRoutine(void* unused)
 		return 0;
 	}
 
-	int tcpSocket = accept(listenSocket, NULL, NULL);
+	g_uartSocket = accept(listenSocket, NULL, NULL);
 	for(;;)
 	{
 		int bytesRead;
 		do
 		{
 			uns8 buf[1024];
-			bytesRead = recv(tcpSocket, buf, sizeof(buf), 0);
+			bytesRead = recv(g_uartSocket, buf, sizeof(buf), 0);
 			printf("%d bytesRead\n", bytesRead);
 			int i;
 			for(i = 0; i < bytesRead; i++)
@@ -114,7 +115,7 @@ void* InterruptRoutine(void* unused)
 		} while(bytesRead > 0);
 		// don't allow immediate reconnection
 		sleep(1);
-		tcpSocket = accept(listenSocket, NULL, NULL);
+		g_uartSocket = accept(listenSocket, NULL, NULL);
 	}
 }
 
@@ -152,6 +153,7 @@ void UART_Init() {}
 void UART_Send(unsigned char ch)
 {
 	printf("%c", ch);
+	send(g_uartSocket, &ch, sizeof(ch), 0);
 }
 void SPI_Init() {}
 char SPI_Send(char data)


### PR DESCRIPTION
- use nanosleep() for faster unit tests
- enable infinite timeout for BroadcastReceiver::operator()
- simplified WiflyControl (always use TcpSockets, we will never use udp for the data connection)
- harmonized usage of timeval in BroadcastReceiver and ComProxy
- hardened ComProxy_ut 
