### PR TITLE
Android proof of concept with simple setcolor

### DIFF
--- a/BroadcastReceiver.cpp
+++ b/BroadcastReceiver.cpp
@@ -73,21 +73,21 @@ uint64_t BroadcastReceiver::GetNextRemote(timeval* timeout)
 	sockaddr_storage remoteAddr;
 	socklen_t remoteAddrLength = sizeof(remoteAddr);
 
-		BroadcastMessage msg;
-		size_t bytesRead = udpSock.RecvFrom((unsigned char*)&msg, sizeof(msg), timeout, (sockaddr*)&remoteAddr, &remoteAddrLength);
-		if(msg.IsWiflyBroadcast(bytesRead))
-		{
-			Endpoint* newRemote = new Endpoint(remoteAddr, remoteAddrLength, msg.port);
+	BroadcastMessage msg;
+	size_t bytesRead = udpSock.RecvFrom((unsigned char*)&msg, sizeof(msg), timeout, (sockaddr*)&remoteAddr, &remoteAddrLength);
+	if(msg.IsWiflyBroadcast(bytesRead))
+	{
+		Endpoint* newRemote = new Endpoint(remoteAddr, remoteAddrLength, msg.port);
 #ifndef OS_ANDROID
-			mMutex.lock();
-			mIpTable.push_back(newRemote);
-			mMutex.unlock();
+		mMutex.lock();
+		mIpTable.push_back(newRemote);
+		mMutex.unlock();
 #else
-			mIpTable.push_back(newRemote);
+		mIpTable.push_back(newRemote);
 #endif /* #ifndef OS_ANDROID */
-			return newRemote->AsUint64();
-		}
-		return 0;
+		return newRemote->AsUint64();
+	}
+	return 0;
 }
 
 uint16_t BroadcastReceiver::GetPort(size_t index) const

--- a/BroadcastReceiver.cpp
+++ b/BroadcastReceiver.cpp
@@ -73,10 +73,6 @@ uint64_t BroadcastReceiver::GetNextRemote(timeval* timeout)
 	sockaddr_storage remoteAddr;
 	socklen_t remoteAddrLength = sizeof(remoteAddr);
 
-	//TODO remove this debugging lines
-	//const Endpoint ep(0x10000202, 0x07D0);
-	//return ep.AsUint64();
-
 		BroadcastMessage msg;
 		size_t bytesRead = udpSock.RecvFrom((unsigned char*)&msg, sizeof(msg), timeout, (sockaddr*)&remoteAddr, &remoteAddrLength);
 		if(msg.IsWiflyBroadcast(bytesRead))

--- a/BroadcastReceiver.cpp
+++ b/BroadcastReceiver.cpp
@@ -67,12 +67,16 @@ uint32_t BroadcastReceiver::GetIp(size_t index) const
 	return mIpTable[index]->m_Addr;
 }
 
-uint32_t BroadcastReceiver::GetNextRemote(timeval* timeout)
+uint64_t BroadcastReceiver::GetNextRemote(timeval* timeout)
 {
 	UdpSocket udpSock(INADDR_ANY, mPort, true, true);
 	sockaddr_storage remoteAddr;
 	socklen_t remoteAddrLength = sizeof(remoteAddr);
-	
+
+	//TODO remove this debugging lines
+	//const Endpoint ep(0x10000202, 0x07D0);
+	//return ep.AsUint64();
+
 		BroadcastMessage msg;
 		size_t bytesRead = udpSock.RecvFrom((unsigned char*)&msg, sizeof(msg), timeout, (sockaddr*)&remoteAddr, &remoteAddrLength);
 		if(msg.IsWiflyBroadcast(bytesRead))
@@ -85,7 +89,7 @@ uint32_t BroadcastReceiver::GetNextRemote(timeval* timeout)
 #else
 			mIpTable.push_back(newRemote);
 #endif /* #ifndef OS_ANDROID */
-			return newRemote->m_Addr;
+			return newRemote->AsUint64();
 		}
 		return 0;
 }

--- a/BroadcastReceiver.cpp
+++ b/BroadcastReceiver.cpp
@@ -37,7 +37,6 @@ BroadcastReceiver::~BroadcastReceiver(void)
 	//TODO cleanup mIpTable
 }
 
-#ifndef OS_ANDROID
 void BroadcastReceiver::operator() (std::ostream& out, timeval* pTimeout)
 {
 	// only one thread allowed per instance
@@ -60,7 +59,6 @@ void BroadcastReceiver::operator() (std::ostream& out, timeval* pTimeout)
 	}
 	std::atomic_fetch_sub(&mNumInstances, 1);
 }
-#endif /* #ifndef OS_ANDROID */
 
 uint32_t BroadcastReceiver::GetIp(size_t index) const
 {
@@ -78,13 +76,9 @@ uint64_t BroadcastReceiver::GetNextRemote(timeval* timeout)
 	if(msg.IsWiflyBroadcast(bytesRead))
 	{
 		Endpoint* newRemote = new Endpoint(remoteAddr, remoteAddrLength, msg.port);
-#ifndef OS_ANDROID
 		mMutex.lock();
 		mIpTable.push_back(newRemote);
 		mMutex.unlock();
-#else
-		mIpTable.push_back(newRemote);
-#endif /* #ifndef OS_ANDROID */
 		return newRemote->AsUint64();
 	}
 	return 0;

--- a/BroadcastReceiver.h
+++ b/BroadcastReceiver.h
@@ -49,7 +49,7 @@ class BroadcastReceiver
 		void operator() (std::ostream& out, timeval* timeout = NULL);
 
 		uint32_t GetIp(size_t index) const;
-		uint64_t GetNextRemote(timeval* timeout);
+		Endpoint GetNextRemote(timeval* timeout);
 		uint16_t GetPort(size_t index) const;
 
 		/**
@@ -63,7 +63,7 @@ class BroadcastReceiver
 		void Stop(void);
 
 	private:
-		std::vector<Endpoint*> mIpTable;
+		std::vector<Endpoint> mIpTable;
 		volatile bool mIsRunning;
 		std::atomic<int> mNumInstances;
 		std::mutex mMutex;

--- a/BroadcastReceiver.h
+++ b/BroadcastReceiver.h
@@ -20,18 +20,13 @@
 #define _BROADCAST_RECEIVER_H_
 
 #include "ClientSocket.h"
+#include <atomic>
 #include <cstdint>
 #include <cstring>
+#include <mutex>
 #include <ostream>
 #include <string>
 #include <vector>
-
-#ifndef OS_ANDROID
-#include <atomic>
-#include <mutex>
-#endif /* #ifndef OS_ANDROID */
-
-using std::vector;
 
 class BroadcastReceiver
 {
@@ -46,14 +41,12 @@ class BroadcastReceiver
 		BroadcastReceiver(uint16_t port = BROADCAST_PORT);
 		~BroadcastReceiver(void);
 
-#ifndef OS_ANDROID
 		/**
 		 * Wait for broadcasts and print them to a stream
 		 * @param out stream to print collected remotes on
 		 * @param timeout in seconds, until execution is terminated
 		 */
 		void operator() (std::ostream& out, timeval* timeout = NULL);
-#endif /* #ifndef OS_ANDROID */
 
 		uint32_t GetIp(size_t index) const;
 		uint64_t GetNextRemote(timeval* timeout);
@@ -70,14 +63,10 @@ class BroadcastReceiver
 		void Stop(void);
 
 	private:
-		vector<Endpoint*> mIpTable;
+		std::vector<Endpoint*> mIpTable;
 		volatile bool mIsRunning;
-#ifndef OS_ANDROID
 		std::atomic<int> mNumInstances;
 		std::mutex mMutex;
-#else
-		int mNumInstances;
-#endif /* #ifndef OS_ANDROID */
 };
 
 #pragma pack(push)

--- a/BroadcastReceiver.h
+++ b/BroadcastReceiver.h
@@ -56,7 +56,7 @@ class BroadcastReceiver
 #endif /* #ifndef OS_ANDROID */
 
 		uint32_t GetIp(size_t index) const;
-		uint32_t GetNextRemote(timeval* timeout);
+		uint64_t GetNextRemote(timeval* timeout);
 		uint16_t GetPort(size_t index) const;
 
 		/**

--- a/BroadcastReceiver_ut.cpp
+++ b/BroadcastReceiver_ut.cpp
@@ -87,7 +87,7 @@ int ut_BroadcastReceiver_TestSimple(void)
 	dummyReceiver.Stop();
 	myThread.join();
 
-	CHECK(0 == out.str().compare("0:7f000001\n"));
+	CHECK(0 == out.str().compare("0:7f000001:2000\n"));
 	CHECK(1 == dummyReceiver.NumRemotes());
 	CHECK(0x7F000001 == dummyReceiver.GetIp(0));
 	TestCaseEnd();
@@ -108,7 +108,7 @@ int ut_BroadcastReceiver_TestTwo(void)
 	dummyReceiver.Stop();
 	myThread.join();
 
-	CHECK(0 == out.str().compare("0:7f000001\n1:7f000001\n"));
+	CHECK(0 == out.str().compare("0:7f000001:2000\n1:7f000001:2000\n"));
 	CHECK(2 == dummyReceiver.NumRemotes());
 	CHECK(0x7F000001 == dummyReceiver.GetIp(0));
 	CHECK(0x7F000001 == dummyReceiver.GetIp(1));
@@ -129,7 +129,7 @@ int ut_BroadcastReceiver_TestNoTimeout(void)
 	dummyReceiver.Stop();
 	myThread.join();
 
-	CHECK(0 == out.str().compare("0:7f000001\n1:7f000001\n"));
+	CHECK(0 == out.str().compare("0:7f000001:2000\n1:7f000001:2000\n"));
 	CHECK(2 == dummyReceiver.NumRemotes());
 	CHECK(0x7F000001 == dummyReceiver.GetIp(0));
 	CHECK(0x7F000001 == dummyReceiver.GetIp(1));

--- a/ClientSocket.h
+++ b/ClientSocket.h
@@ -32,7 +32,16 @@ class Endpoint
 			m_Addr = ntohl(((sockaddr_in&)addr).sin_addr.s_addr);
 			m_Port = ntohs(port);
 		};
+
 		Endpoint(uint32_t addr, uint16_t port) : m_Addr(addr), m_Port(port) {};
+
+		/* 
+		 * @return ipv4 address(A) and port(P) as a combined 64 bit value 0xAAAAAAAA00PP
+		 */
+		uint64_t AsUint64() const {
+			return ((uint64_t)m_Addr << 32) | m_Port; 
+		};
+
 		uint32_t m_Addr;
 		uint16_t m_Port;
 };

--- a/ClientSocket.h
+++ b/ClientSocket.h
@@ -36,7 +36,7 @@ class Endpoint
 		Endpoint(uint32_t addr, uint16_t port) : m_Addr(addr), m_Port(port) {};
 
 		/* 
-		 * @return ipv4 address(A) and port(P) as a combined 64 bit value 0xAAAAAAAA00PP
+		 * @return ipv4 address(A) and port(P) as a combined 64 bit value 0xAAAAAAAA0000PPPP
 		 */
 		uint64_t AsUint64() const {
 			return ((uint64_t)m_Addr << 32) | m_Port; 

--- a/ClientSocket.h
+++ b/ClientSocket.h
@@ -19,9 +19,10 @@
 #ifndef _CLIENTSOCKET_H_
 #define _CLIENTSOCKET_H_
 #include <cassert>
-#include <sys/socket.h>
-#include <netinet/in.h>
+#include <ostream>
 #include <stddef.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
 #include <sys/time.h>
 
 class Endpoint
@@ -33,13 +34,22 @@ class Endpoint
 			m_Port = ntohs(port);
 		};
 
-		Endpoint(uint32_t addr, uint16_t port) : m_Addr(addr), m_Port(port) {};
+		Endpoint(uint32_t addr = 0, uint16_t port = 0) : m_Addr(addr), m_Port(port) {
+		};
+
+		friend std::ostream& operator << (std::ostream& out, const Endpoint& ref) {
+			return out << std::hex << ref.m_Addr << ':' << std::dec << ref.m_Port;
+		};
 
 		/* 
 		 * @return ipv4 address(A) and port(P) as a combined 64 bit value 0xAAAAAAAA0000PPPP
 		 */
-		uint64_t AsUint64() const {
+		uint64_t AsUint64(void) const {
 			return ((uint64_t)m_Addr << 32) | m_Port; 
+		};
+
+		bool IsValid(void) const {
+			return (0 != m_Addr) && (0 != m_Port);
 		};
 
 		uint32_t m_Addr;

--- a/ScriptCtrl.h
+++ b/ScriptCtrl.h
@@ -21,7 +21,7 @@
 
 #include "wifly_cmd.h"
 
-#define SCRIPTCTRL_NUM_CMD_MAX 15
+#define SCRIPTCTRL_NUM_CMD_MAX 63
 #define SCRIPTCTRL_LOOP_DEPTH_MAX 4
 
 struct ScriptBuf {

--- a/WiflyControlJni.cpp
+++ b/WiflyControlJni.cpp
@@ -37,7 +37,7 @@ jlong Java_biz_bruenn_WiflyLight_RemoteCollector_getNextRemote(JNIEnv* env, jobj
 	timeval timeout;
 	timeout.tv_sec = timeoutNanos / 1000000000L;
 	timeout.tv_usec = (timeoutNanos % 1000000000L) / 1000L;
-	return ((BroadcastReceiver*)pNative)->GetNextRemote(&timeout);
+	return ((BroadcastReceiver*)pNative)->GetNextRemote(&timeout).AsUint64();
 }
 
 jlong Java_biz_bruenn_WiflyLight_WiflyControl_create(JNIEnv* env, jobject ref, jint ipv4Addr, jshort port)

--- a/WiflyControlJni.cpp
+++ b/WiflyControlJni.cpp
@@ -40,17 +40,17 @@ jlong Java_biz_bruenn_WiflyLight_RemoteCollector_getNextRemote(JNIEnv* env, jobj
 	return ((BroadcastReceiver*)pNative)->GetNextRemote(&timeout);
 }
 
-jlong Java_biz_bruenn_WiflyLight_WiflyLightActivity_createWiflyControl(JNIEnv* env, jobject ref, jint ipv4Addr, jshort port)
+jlong Java_biz_bruenn_WiflyLight_WiflyControl_create(JNIEnv* env, jobject ref, jint ipv4Addr, jshort port)
 {
 	return (jlong) new WiflyControl(ipv4Addr, port);
 }
 
-jboolean Java_biz_bruenn_WiflyLight_WiflyLightActivity_FwSetColor(JNIEnv* env, jobject ref, jlong pNative, jint addr, jint rgba)
+jboolean Java_biz_bruenn_WiflyLight_WiflyControl_FwSetColor(JNIEnv* env, jobject ref, jlong pNative, jint addr, jint rgba)
 {
 	return reinterpret_cast<WiflyControl*>(pNative)->FwSetColor(addr, rgba);
 }
 
-void Java_biz_bruenn_WiflyLight_WiflyLightActivity_releaseWiflyControl(JNIEnv* env, jobject ref, jlong pNative)
+void Java_biz_bruenn_WiflyLight_WiflyControl_release(JNIEnv* env, jobject ref, jlong pNative)
 {
 	delete (WiflyControl*)pNative;
 }

--- a/WiflyControlJni.cpp
+++ b/WiflyControlJni.cpp
@@ -17,16 +17,11 @@
     along with Wifly_Light.  If not, see <http://www.gnu.org/licenses/>. */
 
 #include "BroadcastReceiver.h"
+#include "WiflyControl.h"
 #include <unistd.h>
 #include <jni.h>
 
 extern "C" {
-jlong Java_biz_bruenn_WiflyLight_RemoteCollector_getNumRemotes(JNIEnv* env, jobject ref, jlong pNative)
-{
-	//sleep(2);
-	return ((BroadcastReceiver*)pNative)->NumRemotes();
-}
-
 jlong Java_biz_bruenn_WiflyLight_RemoteCollector_createBroadcastReceiver(JNIEnv* env, jobject ref)
 {
 	return (jlong) new BroadcastReceiver(BroadcastReceiver::BROADCAST_PORT);
@@ -43,6 +38,21 @@ jlong Java_biz_bruenn_WiflyLight_RemoteCollector_getNextRemote(JNIEnv* env, jobj
 	timeout.tv_sec = timeoutNanos / 1000000000L;
 	timeout.tv_usec = (timeoutNanos % 1000000000L) / 1000L;
 	return ((BroadcastReceiver*)pNative)->GetNextRemote(&timeout);
+}
+
+jlong Java_biz_bruenn_WiflyLight_WiflyLightActivity_createWiflyControl(JNIEnv* env, jobject ref, jint ipv4Addr, jshort port)
+{
+	return (jlong) new WiflyControl(ipv4Addr, port);
+}
+
+jboolean Java_biz_bruenn_WiflyLight_WiflyLightActivity_FwSetColor(JNIEnv* env, jobject ref, jlong pNative, jint addr, jint rgba)
+{
+	return reinterpret_cast<WiflyControl*>(pNative)->FwSetColor(addr, rgba);
+}
+
+void Java_biz_bruenn_WiflyLight_WiflyLightActivity_releaseWiflyControl(JNIEnv* env, jobject ref, jlong pNative)
+{
+	delete (WiflyControl*)pNative;
 }
 }
 

--- a/android/WiflyLight/AndroidManifest.xml
+++ b/android/WiflyLight/AndroidManifest.xml
@@ -5,6 +5,7 @@
     android:versionName="1.0" >
 
     <uses-sdk android:minSdkVersion="10" />
+
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
@@ -14,13 +15,17 @@
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name" >
         <activity
-            android:name=".WiflyLightActivity"
+            android:name="biz.bruenn.WiflyLight.WiflyLightActivity"
             android:label="@string/app_name" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+        </activity>
+        <activity
+            android:name="biz.bruenn.WiflyLight.WiflyControlActivity"
+            android:label="@string/title_activity_wifly_control" >
         </activity>
     </application>
 

--- a/android/WiflyLight/jni/Android.mk
+++ b/android/WiflyLight/jni/Android.mk
@@ -13,5 +13,6 @@ LOCAL_SRC_FILES += $(DIR)intelhexclass.cpp
 LOCAL_SRC_FILES += $(DIR)WiflyControl.cpp
 LOCAL_SRC_FILES += $(DIR)WiflyControlColorClass.cpp
 LOCAL_SRC_FILES += $(DIR)WiflyControlJni.cpp
+LOCAL_C_INCLUDES += $(LOCAL_PATH)/$(DIR)/c++11_wrapper
 
 include $(BUILD_SHARED_LIBRARY)

--- a/android/WiflyLight/jni/Android.mk
+++ b/android/WiflyLight/jni/Android.mk
@@ -13,6 +13,6 @@ LOCAL_SRC_FILES += $(DIR)intelhexclass.cpp
 LOCAL_SRC_FILES += $(DIR)WiflyControl.cpp
 LOCAL_SRC_FILES += $(DIR)WiflyControlColorClass.cpp
 LOCAL_SRC_FILES += $(DIR)WiflyControlJni.cpp
-LOCAL_C_INCLUDES += $(LOCAL_PATH)/$(DIR)/c++11_wrapper
+LOCAL_C_INCLUDES += $(LOCAL_PATH)/$(DIR)c++11_wrapper
 
 include $(BUILD_SHARED_LIBRARY)

--- a/android/WiflyLight/res/layout/activity_wifly_control.xml
+++ b/android/WiflyLight/res/layout/activity_wifly_control.xml
@@ -1,0 +1,48 @@
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".WiflyControlActivity" >
+
+    <TextView
+        android:id="@+id/textView1"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerHorizontal="true"
+        android:layout_centerVertical="true"
+        android:text="@string/hello_world" />
+
+    <SeekBar
+        android:id="@+id/seekBar1"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentTop="true"
+        android:layout_marginTop="30dp" />
+
+    <SeekBar
+        android:id="@+id/seekBar2"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentLeft="true"
+        android:layout_below="@+id/seekBar1"
+        android:layout_marginTop="48dp" />
+
+    <SeekBar
+        android:id="@+id/seekBar3"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_above="@+id/textView1"
+        android:layout_alignParentLeft="true"
+        android:layout_marginBottom="32dp" />
+
+    <Button
+        android:id="@+id/button1"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignRight="@+id/textView1"
+        android:layout_below="@+id/textView1"
+        android:layout_marginRight="28dp"
+        android:text="Button" />
+
+</RelativeLayout>

--- a/android/WiflyLight/res/layout/activity_wifly_control.xml
+++ b/android/WiflyLight/res/layout/activity_wifly_control.xml
@@ -4,45 +4,33 @@
     android:layout_height="match_parent"
     tools:context=".WiflyControlActivity" >
 
-    <TextView
-        android:id="@+id/textView1"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_centerHorizontal="true"
-        android:layout_centerVertical="true"
-        android:text="@string/hello_world" />
-
     <SeekBar
-        android:id="@+id/seekBar1"
+        android:id="@+id/red"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentLeft="true"
-        android:layout_alignParentTop="true"
-        android:layout_marginTop="30dp" />
+        android:layout_alignParentTop="true"  />
 
     <SeekBar
-        android:id="@+id/seekBar2"
+        android:id="@+id/green"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_alignParentLeft="true"
-        android:layout_below="@+id/seekBar1"
-        android:layout_marginTop="48dp" />
+        android:layout_below="@+id/red" />
 
     <SeekBar
-        android:id="@+id/seekBar3"
+        android:id="@+id/blue"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_above="@+id/textView1"
-        android:layout_alignParentLeft="true"
-        android:layout_marginBottom="32dp" />
+        android:layout_below="@+id/green" />
 
     <Button
-        android:id="@+id/button1"
+        android:id="@+id/setColor"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_alignRight="@+id/textView1"
-        android:layout_below="@+id/textView1"
+        android:layout_below="@+id/blue"
+        android:layout_centerHorizontal="true"
+        android:layout_centerVertical="true"
         android:layout_marginRight="28dp"
-        android:text="Button" />
+        android:text="@string/set_color" />
 
 </RelativeLayout>

--- a/android/WiflyLight/res/values/strings.xml
+++ b/android/WiflyLight/res/values/strings.xml
@@ -5,7 +5,7 @@
     <string name="hello">Hello World, WiflyLightActivity!</string>
     <string name="scan">Scan</string>
     <string name="scanning">Scanning...</string>
-    <string name="hello_world">Hello world!</string>
+    <string name="set_color">Set color</string>
     <string name="menu_settings">Settings</string>
     <string name="title_activity_wifly_control">WiflyControlActivity</string>
 

--- a/android/WiflyLight/res/values/strings.xml
+++ b/android/WiflyLight/res/values/strings.xml
@@ -5,5 +5,8 @@
     <string name="hello">Hello World, WiflyLightActivity!</string>
     <string name="scan">Scan</string>
     <string name="scanning">Scanning...</string>
+    <string name="hello_world">Hello world!</string>
+    <string name="menu_settings">Settings</string>
+    <string name="title_activity_wifly_control">WiflyControlActivity</string>
 
 </resources>

--- a/android/WiflyLight/src/biz/bruenn/WiflyLight/Endpoint.java
+++ b/android/WiflyLight/src/biz/bruenn/WiflyLight/Endpoint.java
@@ -1,0 +1,28 @@
+package biz.bruenn.WiflyLight;
+
+public class Endpoint {
+	private final int mAddr;
+	private final short mPort;
+	
+	public Endpoint(long remote) {
+		mAddr = (int)(remote >> 32);
+		mPort = (short)(remote & 0x000000000000ffffL);
+	}
+	
+	public int getAddr() {
+		return mAddr;
+	}
+	
+	public int getPort() {
+		return mPort;
+	}
+	
+	public boolean isValid() {
+		return (0 != mAddr) && (0 != mPort);
+	}
+	
+	@Override
+	public String toString() {
+		return Integer.toHexString(mAddr) + ':' + String.valueOf(mPort);
+	}
+}

--- a/android/WiflyLight/src/biz/bruenn/WiflyLight/RemoteCollector.java
+++ b/android/WiflyLight/src/biz/bruenn/WiflyLight/RemoteCollector.java
@@ -10,7 +10,6 @@ import android.widget.Button;
 
 public class RemoteCollector extends AsyncTask<Long, Void, Void> {
 	private native long createBroadcastReceiver();
-	private native long getNumRemotes(long pNative);
 	private native long getNextRemote(long pNative, long timeoutNanos);
 	private native void releaseBroadcastReceiver(long pNative);
 	

--- a/android/WiflyLight/src/biz/bruenn/WiflyLight/RemoteCollector.java
+++ b/android/WiflyLight/src/biz/bruenn/WiflyLight/RemoteCollector.java
@@ -13,13 +13,13 @@ public class RemoteCollector extends AsyncTask<Long, Void, Void> {
 	private native long getNextRemote(long pNative, long timeoutNanos);
 	private native void releaseBroadcastReceiver(long pNative);
 	
-	private ArrayAdapter<String> mRemoteArrayAdapter;
-	private ArrayList<String> mRemoteArray;
+	private ArrayAdapter<Endpoint> mRemoteArrayAdapter;
+	private ArrayList<Endpoint> mRemoteArray;
 	private WifiManager.MulticastLock mMulticastLock; 
 	private long mNative = 0;
 	private Button mScanBtn;
 	
-	public RemoteCollector(WifiManager wifiMgr, ArrayList<String> remoteArray, ArrayAdapter<String> remoteArrayAdapter, Button scanBtn) {
+	public RemoteCollector(WifiManager wifiMgr, ArrayList<Endpoint> remoteArray, ArrayAdapter<Endpoint> remoteArrayAdapter, Button scanBtn) {
 		mMulticastLock = wifiMgr.createMulticastLock("WiflyLight_MulticastLock");
 		mNative = createBroadcastReceiver();
 		mRemoteArray = remoteArray;
@@ -41,10 +41,11 @@ public class RemoteCollector extends AsyncTask<Long, Void, Void> {
 		
 		mMulticastLock.acquire();
 		while(!isCancelled() && (timeoutNanos > 0)) {
-			long remote = getNextRemote(mNative, timeoutNanos);
-			if(0 != remote)
+			Endpoint remote = new Endpoint(getNextRemote(mNative, timeoutNanos));
+			
+			if(remote.isValid())
 			{
-				mRemoteArray.add(String.valueOf(remote));
+				mRemoteArray.add(remote);
 				publishProgress();
 			}
 			timeoutNanos = endTime - System.nanoTime();

--- a/android/WiflyLight/src/biz/bruenn/WiflyLight/WiflyControl.java
+++ b/android/WiflyLight/src/biz/bruenn/WiflyLight/WiflyControl.java
@@ -1,0 +1,21 @@
+package biz.bruenn.WiflyLight;
+
+public class WiflyControl {
+	private native long create(int ipv4Addr, short port);
+	private native boolean FwSetColor(long pNative, int addr, int rgba);
+	private native void release(long pNative);
+	
+	private final long mNative;
+	
+	WiflyControl(int ipv4Addr, short port) {
+		mNative = create(ipv4Addr, port);
+	}
+	
+	public void finalize() throws Throwable {
+		release(mNative);
+	}
+	
+	boolean fwSetColor(int addr, int rgba) {
+		return FwSetColor(mNative, addr, rgba);
+	}
+}

--- a/android/WiflyLight/src/biz/bruenn/WiflyLight/WiflyControlActivity.java
+++ b/android/WiflyLight/src/biz/bruenn/WiflyLight/WiflyControlActivity.java
@@ -1,0 +1,31 @@
+package biz.bruenn.WiflyLight;
+
+import android.os.Bundle;
+import android.app.Activity;
+import android.content.Intent;
+import android.view.Menu;
+import android.widget.Toast;
+
+public class WiflyControlActivity extends Activity {
+
+	@Override
+	protected void onCreate(Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+		setContentView(R.layout.activity_wifly_control);
+		Intent i = getIntent();
+		int ip = i.getIntExtra("IpAddress", 0);
+		short port = i.getShortExtra("Port", (short)2000);
+
+		WiflyControl ctrl = new WiflyControl(ip, port);
+		boolean done = ctrl.fwSetColor(0xffffffff, 0xff000000);
+		Toast.makeText(getApplicationContext(), String.valueOf(done), Toast.LENGTH_SHORT).show();
+	}
+
+	@Override
+	public boolean onCreateOptionsMenu(Menu menu) {
+		// Inflate the menu; this adds items to the action bar if it is present.
+		getMenuInflater().inflate(R.menu.activity_wifly_control, menu);
+		return true;
+	}
+
+}

--- a/android/WiflyLight/src/biz/bruenn/WiflyLight/WiflyControlActivity.java
+++ b/android/WiflyLight/src/biz/bruenn/WiflyLight/WiflyControlActivity.java
@@ -12,6 +12,7 @@ import android.widget.Toast;
 public class WiflyControlActivity extends Activity {
 	public static final String EXTRA_IP = "IpAddress";
 	public static final String EXTRA_PORT = "Port";
+	public static final short DEFAULT_PORT = 2000;
 	
 	private WiflyControl mCtrl;
 	private Button mSetColorBtn;
@@ -26,7 +27,7 @@ public class WiflyControlActivity extends Activity {
 		setContentView(R.layout.activity_wifly_control);
 		Intent i = getIntent();
 		int ip = i.getIntExtra(EXTRA_IP, 0);
-		short port = i.getShortExtra(EXTRA_PORT, (short)2000);
+		short port = i.getShortExtra(EXTRA_PORT, DEFAULT_PORT);
 		mCtrl = new WiflyControl(ip, port);
 		
 		mSetColorBtn = (Button)findViewById(R.id.setColor);

--- a/android/WiflyLight/src/biz/bruenn/WiflyLight/WiflyControlActivity.java
+++ b/android/WiflyLight/src/biz/bruenn/WiflyLight/WiflyControlActivity.java
@@ -4,21 +4,80 @@ import android.os.Bundle;
 import android.app.Activity;
 import android.content.Intent;
 import android.view.Menu;
+import android.view.View;
+import android.widget.Button;
+import android.widget.SeekBar;
 import android.widget.Toast;
 
 public class WiflyControlActivity extends Activity {
+	public static final String EXTRA_IP = "IpAddress";
+	public static final String EXTRA_PORT = "Port";
+	
+	private WiflyControl mCtrl;
+	private Button mSetColorBtn;
+	private SeekBar mRed;
+	private SeekBar mGreen;
+	private SeekBar mBlue;
+	private int mColor = 0xff000000;
 
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		setContentView(R.layout.activity_wifly_control);
 		Intent i = getIntent();
-		int ip = i.getIntExtra("IpAddress", 0);
-		short port = i.getShortExtra("Port", (short)2000);
+		int ip = i.getIntExtra(EXTRA_IP, 0);
+		short port = i.getShortExtra(EXTRA_PORT, (short)2000);
+		mCtrl = new WiflyControl(ip, port);
+		
+		mSetColorBtn = (Button)findViewById(R.id.setColor);
+		mSetColorBtn.setOnClickListener(new View.OnClickListener() {
+			public void onClick(View v) {
+				int c = mColor << 8;
+				boolean done = mCtrl.fwSetColor(0xffffffff, c);
+				Toast.makeText(getApplicationContext(), String.valueOf(done), Toast.LENGTH_SHORT).show();
+			}
+		});
+		
 
-		WiflyControl ctrl = new WiflyControl(ip, port);
-		boolean done = ctrl.fwSetColor(0xffffffff, 0xff000000);
-		Toast.makeText(getApplicationContext(), String.valueOf(done), Toast.LENGTH_SHORT).show();
+		mRed = (SeekBar)findViewById(R.id.red);
+		mRed.setMax(255);
+		mRed.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
+			public void onStopTrackingTouch(SeekBar seekBar) {
+			}
+			public void onStartTrackingTouch(SeekBar seekBar) {	
+			}
+			public void onProgressChanged(SeekBar seekBar, int progress,
+					boolean fromUser) {
+				mColor = (mColor & 0xff00ffff) | (progress << 16);
+				mSetColorBtn.setBackgroundColor(mColor);
+			}
+		});
+		mGreen = (SeekBar)findViewById(R.id.green);
+		mGreen.setMax(255);
+		mGreen.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
+			public void onStopTrackingTouch(SeekBar seekBar) {
+			}
+			public void onStartTrackingTouch(SeekBar seekBar) {	
+			}
+			public void onProgressChanged(SeekBar seekBar, int progress,
+					boolean fromUser) {
+				mColor = (mColor & 0xffff00ff) | (progress << 8);
+				mSetColorBtn.setBackgroundColor(mColor);
+			}
+		});
+		mBlue = (SeekBar)findViewById(R.id.blue);
+		mBlue.setMax(255);
+		mBlue.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
+			public void onStopTrackingTouch(SeekBar seekBar) {
+			}
+			public void onStartTrackingTouch(SeekBar seekBar) {	
+			}
+			public void onProgressChanged(SeekBar seekBar, int progress,
+					boolean fromUser) {
+				mColor = (mColor & 0xffffff00) | (progress);
+				mSetColorBtn.setBackgroundColor(mColor);
+			}
+		});
 	}
 
 	@Override
@@ -27,5 +86,10 @@ public class WiflyControlActivity extends Activity {
 		getMenuInflater().inflate(R.menu.activity_wifly_control, menu);
 		return true;
 	}
-
+	
+	@Override
+	protected void onDestroy() {
+		mCtrl = null;
+		super.onDestroy();
+	}
 }

--- a/android/WiflyLight/src/biz/bruenn/WiflyLight/WiflyLightActivity.java
+++ b/android/WiflyLight/src/biz/bruenn/WiflyLight/WiflyLightActivity.java
@@ -6,6 +6,7 @@ import biz.bruenn.WiflyLight.R.id;
 import biz.bruenn.WiflyLight.R.string;
 import android.app.Activity;
 import android.content.Context;
+import android.content.Intent;
 import android.net.wifi.WifiManager;
 import android.os.Bundle;
 import android.view.View;
@@ -35,11 +36,18 @@ public class WiflyLightActivity extends Activity {
         mRemoteList.setAdapter(mRemoteArrayAdapter);
         mRemoteList.setOnItemClickListener(new AdapterView.OnItemClickListener() {
 
-			public void onItemClick(AdapterView<?> arg0, View arg1, int arg2,
+			public void onItemClick(AdapterView<?> arg0, View v, int arg2,
 					long arg3) {
+				mRemoteArrayAdapter.getItem(arg2);
+				Intent i = new Intent(v.getContext(), WiflyControlActivity.class);
+				i.putExtra("IpAddress", 0x0A000202);
+				i.putExtra("Port", (short)2000);
+				startActivityForResult(i, 0);
+				/*
 				WiflyControl ctrl = new WiflyControl(0x0A000202, (short)2000);
 				boolean done = ctrl.fwSetColor(0xffffffff, 0xff000000);
 				Toast.makeText(getApplicationContext(), String.valueOf(done), Toast.LENGTH_SHORT).show();
+				*/
 			}
 		});
         

--- a/android/WiflyLight/src/biz/bruenn/WiflyLight/WiflyLightActivity.java
+++ b/android/WiflyLight/src/biz/bruenn/WiflyLight/WiflyLightActivity.java
@@ -14,7 +14,6 @@ import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.ListView;
-import android.widget.Toast;
 
 public class WiflyLightActivity extends Activity {
 	private ListView mRemoteList;
@@ -40,14 +39,9 @@ public class WiflyLightActivity extends Activity {
 					long arg3) {
 				mRemoteArrayAdapter.getItem(arg2);
 				Intent i = new Intent(v.getContext(), WiflyControlActivity.class);
-				i.putExtra("IpAddress", 0x0A000202);
-				i.putExtra("Port", (short)2000);
+				i.putExtra(WiflyControlActivity.EXTRA_IP, 0x0A000202);
+				i.putExtra(WiflyControlActivity.EXTRA_PORT, (short)2000);
 				startActivityForResult(i, 0);
-				/*
-				WiflyControl ctrl = new WiflyControl(0x0A000202, (short)2000);
-				boolean done = ctrl.fwSetColor(0xffffffff, 0xff000000);
-				Toast.makeText(getApplicationContext(), String.valueOf(done), Toast.LENGTH_SHORT).show();
-				*/
 			}
 		});
         

--- a/android/WiflyLight/src/biz/bruenn/WiflyLight/WiflyLightActivity.java
+++ b/android/WiflyLight/src/biz/bruenn/WiflyLight/WiflyLightActivity.java
@@ -16,9 +16,6 @@ import android.widget.ListView;
 import android.widget.Toast;
 
 public class WiflyLightActivity extends Activity {
-	private native long createWiflyControl(int ipv4Addr, short port);
-	private native boolean FwSetColor(long pNative, int addr, int rgba);
-	private native void releaseWiflyControl(long pNative);
 	private ListView mRemoteList;
 	private ArrayList<String> mRemoteArray = new ArrayList<String>();
 	ArrayAdapter<String> mRemoteArrayAdapter;
@@ -40,10 +37,9 @@ public class WiflyLightActivity extends Activity {
 
 			public void onItemClick(AdapterView<?> arg0, View arg1, int arg2,
 					long arg3) {
-				long wiflyControl = createWiflyControl(0x0A000202, (short)2000);
-				boolean done = FwSetColor(wiflyControl, 0xffffffff, 0xff000000);
+				WiflyControl ctrl = new WiflyControl(0x0A000202, (short)2000);
+				boolean done = ctrl.fwSetColor(0xffffffff, 0xff000000);
 				Toast.makeText(getApplicationContext(), String.valueOf(done), Toast.LENGTH_SHORT).show();
-				releaseWiflyControl(wiflyControl);
 			}
 		});
         

--- a/android/WiflyLight/src/biz/bruenn/WiflyLight/WiflyLightActivity.java
+++ b/android/WiflyLight/src/biz/bruenn/WiflyLight/WiflyLightActivity.java
@@ -17,8 +17,8 @@ import android.widget.ListView;
 
 public class WiflyLightActivity extends Activity {
 	private ListView mRemoteList;
-	private ArrayList<String> mRemoteArray = new ArrayList<String>();
-	ArrayAdapter<String> mRemoteArrayAdapter;
+	private ArrayList<Endpoint> mRemoteArray = new ArrayList<Endpoint>();
+	ArrayAdapter<Endpoint> mRemoteArrayAdapter;
 	
 	static {
 		System.loadLibrary("wifly");
@@ -31,16 +31,16 @@ public class WiflyLightActivity extends Activity {
         setContentView(R.layout.main);
 
         mRemoteList = (ListView)findViewById(id.remoteList);
-        mRemoteArrayAdapter = new ArrayAdapter<String>(this, android.R.layout.simple_list_item_1, mRemoteArray);
+        mRemoteArrayAdapter = new ArrayAdapter<Endpoint>(this, android.R.layout.simple_list_item_1, mRemoteArray);
         mRemoteList.setAdapter(mRemoteArrayAdapter);
         mRemoteList.setOnItemClickListener(new AdapterView.OnItemClickListener() {
 
 			public void onItemClick(AdapterView<?> arg0, View v, int arg2,
 					long arg3) {
-				mRemoteArrayAdapter.getItem(arg2);
+				Endpoint e = mRemoteArrayAdapter.getItem(arg2);
 				Intent i = new Intent(v.getContext(), WiflyControlActivity.class);
-				i.putExtra(WiflyControlActivity.EXTRA_IP, 0x0A000202);
-				i.putExtra(WiflyControlActivity.EXTRA_PORT, (short)2000);
+				i.putExtra(WiflyControlActivity.EXTRA_IP, e.getAddr());
+				i.putExtra(WiflyControlActivity.EXTRA_PORT, e.getPort());
 				startActivityForResult(i, 0);
 			}
 		});

--- a/android/WiflyLight/src/biz/bruenn/WiflyLight/WiflyLightActivity.java
+++ b/android/WiflyLight/src/biz/bruenn/WiflyLight/WiflyLightActivity.java
@@ -9,11 +9,16 @@ import android.content.Context;
 import android.net.wifi.WifiManager;
 import android.os.Bundle;
 import android.view.View;
+import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.ListView;
+import android.widget.Toast;
 
 public class WiflyLightActivity extends Activity {
+	private native long createWiflyControl(int ipv4Addr, short port);
+	private native boolean FwSetColor(long pNative, int addr, int rgba);
+	private native void releaseWiflyControl(long pNative);
 	private ListView mRemoteList;
 	private ArrayList<String> mRemoteArray = new ArrayList<String>();
 	ArrayAdapter<String> mRemoteArrayAdapter;
@@ -31,6 +36,16 @@ public class WiflyLightActivity extends Activity {
         mRemoteList = (ListView)findViewById(id.remoteList);
         mRemoteArrayAdapter = new ArrayAdapter<String>(this, android.R.layout.simple_list_item_1, mRemoteArray);
         mRemoteList.setAdapter(mRemoteArrayAdapter);
+        mRemoteList.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+
+			public void onItemClick(AdapterView<?> arg0, View arg1, int arg2,
+					long arg3) {
+				long wiflyControl = createWiflyControl(0x0A000202, (short)2000);
+				boolean done = FwSetColor(wiflyControl, 0xffffffff, 0xff000000);
+				Toast.makeText(getApplicationContext(), String.valueOf(done), Toast.LENGTH_SHORT).show();
+				releaseWiflyControl(wiflyControl);
+			}
+		});
         
         Button scanBtn = (Button)findViewById(id.scan);
         scanBtn.setOnClickListener(new View.OnClickListener() {

--- a/c++11_wrapper/atomic
+++ b/c++11_wrapper/atomic
@@ -1,0 +1,42 @@
+/**
+ Copyright (C) 2013 Nils Weiss, Patrick Bruenn.
+ 
+ This file is part of Wifly_Light.
+ 
+ Wifly_Light is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ Wifly_Light is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with Wifly_Light.  If not, see <http://www.gnu.org/licenses/>. */
+
+#if defined(__cplusplus) && (__cplusplus < 201103L)
+#warning "Check for a newer compiler to avoid using this C++11 wrapper file"
+#ifndef _CPP11_WRAPPER_ATOMIC_
+#define _CPP11_WRAPPER_ATOMIC_
+namespace std {
+template<class T>
+struct atomic {
+	T data;
+	atomic(T v) : data(v) {};
+};
+
+template<typename T>
+inline T atomic_fetch_add(atomic<T>* pObj, T value) {
+	return __sync_fetch_and_add(&pObj->data, value);
+};
+
+template<typename T>
+inline T atomic_fetch_sub(atomic<T>* pObj, T value) {
+	return __sync_fetch_and_sub(&pObj->data, value);
+};
+} /* namespace std { */
+#endif /* #ifndef _CPP11_WRAPPER_ATOMIC_ */
+#endif /* #if defined(__cplusplus) && (__cplusplus < 201103L) */
+

--- a/c++11_wrapper/mutex
+++ b/c++11_wrapper/mutex
@@ -1,0 +1,41 @@
+/**
+ Copyright (C) 2013 Nils Weiss, Patrick Bruenn.
+ 
+ This file is part of Wifly_Light.
+ 
+ Wifly_Light is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ Wifly_Light is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with Wifly_Light.  If not, see <http://www.gnu.org/licenses/>. */
+
+#if defined(__cplusplus) && (__cplusplus < 201103L)
+#warning "Check for a newer compiler to avoid using this C++11 wrapper file"
+#ifndef _CPP11_WRAPPER_MUTEX_
+#define _CPP11_WRAPPER_MUTEX_
+#include <pthread.h>
+namespace std {
+class mutex {
+	pthread_mutex_t mMutex;
+	public:
+		mutex(void) : mMutex(PTHREAD_MUTEX_INITIALIZER) {};
+
+		void lock(void) {
+			pthread_mutex_lock(&mMutex);
+		};
+
+		void unlock(void) {
+			pthread_mutex_unlock(&mMutex);
+		};
+};
+} /* namespace std { */
+#endif /* #ifndef _CPP11_WRAPPER_MUTEX_ */
+#endif /* #if defined(__cplusplus) && (__cplusplus < 201103L) */
+

--- a/todo.txt
+++ b/todo.txt
@@ -3,7 +3,7 @@ Bug:
 
 
 Refactoring:
-- make extract timeval functions from ComProxy and BroadcastReceiver
+
 
 
 Improvement: fix rules in Makefile


### PR DESCRIPTION
example improved
simple Seekbars for rgb color selection

by the way Java knows RGBA too, but there it is ARGB. how is it on IOS? maybe we should switch our library to the same behaviour

removed #ifdef OS_ANDROID
ich habe die #ifndef OS_ANDROID entfernt, die waren nur wegen den c++11 features atomic und mutex drin. Ich habe jetzt auf basis von gcc und posix eine alternative für systeme wo die c++11 features noch nicht verfügbar sind gebaut und unter c++11_wrapper/ abgelegt. Unter android läufts. Probiers doch mal bitte mit IOS aus sollte eigentlich auch problem los gehen.
Soweit ich gelesen habe unterstützt der Clang die gcc befehle die ich benutzt habe.
