### PR TITLE
error handling for WiflyControl::Fw..() functions

### DIFF
--- a/android/WiflyLight/AndroidManifest.xml
+++ b/android/WiflyLight/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="biz.bruenn.WiflyLight"
-    android:versionCode="1"
-    android:versionName="0.1" >
+    android:versionCode="2"
+    android:versionName="0.2" >
 
     <uses-sdk android:minSdkVersion="10" />
 

--- a/android/WiflyLight/jni/Android.mk
+++ b/android/WiflyLight/jni/Android.mk
@@ -10,6 +10,7 @@ LOCAL_SRC_FILES += $(LIB_SRC)BroadcastReceiver.cpp
 LOCAL_SRC_FILES += $(LIB_SRC)ClientSocket.cpp
 LOCAL_SRC_FILES += $(LIB_SRC)ComProxy.cpp
 LOCAL_SRC_FILES += $(LIB_SRC)intelhexclass.cpp
+LOCAL_SRC_FILES += $(LIB_SRC)MaskBuffer.cpp
 LOCAL_SRC_FILES += $(LIB_SRC)TelnetProxy.cpp
 LOCAL_SRC_FILES += $(LIB_SRC)WiflyControl.cpp
 LOCAL_SRC_FILES += WiflyControlJni.cpp

--- a/cli/WiflyControlCmd.h
+++ b/cli/WiflyControlCmd.h
@@ -533,7 +533,7 @@ class ControlCmdWait : public WiflyControlCmd
 			+ string("    <time> the number of milliseconds the wait should take")) {};
 
 		virtual void Run(WiflyControl& control) const {
-			uint32_t waitTmms;
+			uint16_t waitTmms;
 			cin >> waitTmms;
 			cout << "Transmitting command wait... ";
 			try
@@ -561,7 +561,7 @@ class ControlCmdSetFade : public WiflyControlCmd
 
 		virtual void Run(WiflyControl& control) const {
 			string addr, color;
-			uint32_t timevalue;
+			uint16_t timevalue;
 			cin >> addr;
 			cin >> color;
 			cin >> timevalue;

--- a/firmware/VersionFile.h
+++ b/firmware/VersionFile.h
@@ -1,6 +1,6 @@
 #ifndef __VERFILE_H__
 #define __VERFILE_H__
 
-#define VER_STRING "001.030"
+#define VER_STRING "001.031"
 
 #endif

--- a/firmware/timer.c
+++ b/firmware/timer.c
@@ -19,7 +19,7 @@
 #include "timer.h"
 #include "trace.h"
 
-bank3 struct CycleTimeBuffer g_CycleTimeBuffer;
+struct CycleTimeBuffer g_CycleTimeBuffer;
 enum CYCLETIME_METHODE enumMethode;
 
 void Timer_Init()
@@ -32,18 +32,18 @@ void Timer_Init()
 	 * T1 Interrupt occures with a frequency of 30 Hz.
 	 * This is used to update the ledstrip with the current colorvalue
 	 */
-	T1CON = 0b00100111;
+	T1CON = 0b00110111;
 	TMR1IE = TRUE;
 	
 	/*
 	 * T5 Interrupt every 5 Millisecounds if clock is 64MHz
 	 * Calculation
-	 * 64000000 Hz / 8 / 40000
+	 * 64000000 Hz / 4 / 8 / 5000
 	 */
-	T5CON = 0b01110111;
+	T5CON = 0b00110111;
 	TMR5IE = TRUE;
-	TMR5H = 0x63;
-	TMR5L = 0xC0;
+	TMR5H = 0xEC;
+	TMR5L = 0x78;
 	/* 
 	** T4 Interrupt every 4 Millisecound if clock is 64MHz
 	** Calculation

--- a/firmware/timer.h
+++ b/firmware/timer.h
@@ -43,7 +43,7 @@ struct CycleTimeBuffer{
 	uns16 tempCycleTime[CYCLETIME_METHODE_ENUM_SIZE];
 };
 
-extern bank3 struct CycleTimeBuffer g_CycleTimeBuffer;
+extern struct CycleTimeBuffer g_CycleTimeBuffer;
 
 void Timer_Init();
 
@@ -65,7 +65,7 @@ uns8 Timer_PrintCycletime(uns16 *pArray, const uns16 arraySize);
 #define Timer2Interrupt(x) TMR2IF = 0;
 #define Timer3Interrupt(x) TMR3IF = 0;
 #define Timer4Interrupt(x) TMR4IF = 0;
-#define Timer5Interrupt(x) TMR5IF = 0; TMR5H = 0x63; TMR5L = 0xC0;
+#define Timer5Interrupt(x) TMR5IF = 0; TMR5H = 0xEC; TMR5L = 0x78;
 
 #define Timer1Enable(x) TMR1ON = 1;
 #define Timer1Disable(x) TMR1ON = 0;

--- a/library/Makefile
+++ b/library/Makefile
@@ -2,7 +2,7 @@ CC=g++
 CFLAGS =-Wall
 CFLAGS+=-pedantic
 CFLAGS+=-std=c++0x
-FILES=BroadcastReceiver.cpp ClientSocket.cpp ComProxy.cpp intelhexclass.cpp TelnetProxy.cpp WiflyControl.cpp 
+FILES=BroadcastReceiver.cpp ClientSocket.cpp ComProxy.cpp intelhexclass.cpp MaskBuffer.cpp TelnetProxy.cpp WiflyControl.cpp 
 FW_FILES=../firmware/crc.c
 FW_HEADERS=../firmware/trace.h ../firmware/unittest.h
 INC=-I../firmware

--- a/library/Makefile
+++ b/library/Makefile
@@ -25,12 +25,12 @@ libWiflyControl.a: outdir $(OBJ)
 outdir:
 	mkdir -p ${OUT_DIR}
 
-BroadcastReceiver_ut.bin: BroadcastReceiver_ut.cpp BroadcastReceiver.cpp BroadcastReceiver.h ClientSocket.cpp ClientSocket.h $(FW_HEADERS)
+BroadcastReceiver_ut.bin: MaskBuffer.cpp BroadcastReceiver_ut.cpp BroadcastReceiver.cpp BroadcastReceiver.h ClientSocket.cpp ClientSocket.h $(FW_HEADERS)
 	@g++ BroadcastReceiver_ut.cpp BroadcastReceiver.cpp $(INC) -lpthread -o $@ -Wall -std=c++0x
 	@./$@
 
-ComProxy_ut.bin: ComProxy_ut.cpp ComProxy.cpp ComProxy.h BlRequest.h MaskBuffer.h $(FW_HEADERS)
-	@g++ ComProxy_ut.cpp ComProxy.cpp $(FW_FILES) $(INC) -o $@ -Wall -pedantic -std=c++0x
+ComProxy_ut.bin: ComProxy_ut.cpp ComProxy.cpp ComProxy.h BlRequest.h $(FW_HEADERS)
+	@g++ ComProxy_ut.cpp ComProxy.cpp MaskBuffer.cpp $(FW_FILES) $(INC) -o $@ -Wall -pedantic -std=c++0x
 	@./$@
 
 TelnetProxy_ut.bin: TelnetProxy_ut.cpp TelnetProxy.cpp TelnetProxy.h $(FW_HEADERS)

--- a/library/MaskBuffer.cpp
+++ b/library/MaskBuffer.cpp
@@ -1,0 +1,9 @@
+//
+//  MaskBuffer.cpp
+//  WiflyControlCli
+//
+//  Created by Nils Weiß on 28.03.13.
+//  Copyright (c) 2013 Nils Weiß. All rights reserved.
+//
+
+#include "MaskBuffer.h"

--- a/library/MaskBuffer.cpp
+++ b/library/MaskBuffer.cpp
@@ -1,9 +1,152 @@
-//
-//  MaskBuffer.cpp
-//  WiflyControlCli
-//
-//  Created by Nils Weiß on 28.03.13.
-//  Copyright (c) 2013 Nils Weiß. All rights reserved.
-//
+/**
+ Copyright (C) 2012, 2013 Nils Weiss, Patrick Bruenn.
+ 
+ This file is part of Wifly_Light.
+ 
+ Wifly_Light is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ Wifly_Light is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with Wifly_Light.  If not, see <http://www.gnu.org/licenses/>. */
 
 #include "MaskBuffer.h"
+#include "trace.h"
+
+static const uint32_t g_DebugZones = ZONE_ERROR | ZONE_WARNING | ZONE_INFO | ZONE_VERBOSE;
+
+
+void BaseBuffer::AddPure(uint8_t newByte)
+{
+	if(mLength >= mCapacity) throw FatalError("BaseBuffer overflow");
+		mData[mLength] = newByte;
+		mLength++;
+}
+
+void MaskBuffer::Mask(const uint8_t* pInput, const uint8_t* const pInputEnd, const bool crcInLittleEndian)
+{
+	while(pInput < pInputEnd)
+	{
+		AddWithCrc(*pInput);
+		pInput++;
+	}
+	AppendCrc(crcInLittleEndian);
+	AddPure(BL_ETX);
+}
+
+void MaskBuffer::Add(uint8_t newByte)
+{
+	if(IsCtrlChar(newByte))
+	{
+		AddPure(BL_DLE);
+	}
+	AddPure(newByte);
+}
+
+void MaskBuffer::AddWithCrc(uint8_t newByte)
+{
+	Add(newByte);
+	Crc_AddCrc16(newByte, &mCrc);
+}
+
+void MaskBuffer::AppendCrc(bool crcInLittleEndian)
+{
+	if(crcInLittleEndian)
+	{
+		Add((uint8_t)(mCrc & 0xff));
+		Add((uint8_t)(mCrc >> 8));
+	}
+	else
+	{
+		Add((uint8_t)(mCrc >> 8));
+		Add((uint8_t)(mCrc & 0xff));
+	}
+}
+
+void UnmaskBuffer::Add(uint8_t newByte)
+{
+	AddPure(newByte);
+	AddToCrc(newByte);
+}
+
+void UnmaskBuffer::Clear(void)
+{
+	BaseBuffer::Clear();
+	mPrePreCrc = mPreCrc = 0;
+	mLastWasDLE = false;
+}
+
+void UnmaskBuffer::CheckAndRemoveCrc(bool crcInLittleEndian) throw (FatalError)
+{
+	if(0x0000 == GetCrc16(crcInLittleEndian))
+	{
+		if(2 > mLength) throw FatalError("Buffer underrun in UnmaskBuffer");
+		mLength -= 2;
+	}
+	else
+	{
+		Clear();
+	}
+}
+
+bool UnmaskBuffer::Unmask(const uint8_t* pInput, size_t bytesMasked, bool checkCrc, bool crcInLittleEndian)
+{
+	while(bytesMasked-- > 0)
+	{
+		if(mLastWasDLE)
+		{
+			mLastWasDLE = false;
+			Add(*pInput);
+		}
+		else
+		{
+			switch(*pInput)
+			{
+				case BL_ETX:
+					Trace(ZONE_INFO, "Detect ETX\n");
+					if(checkCrc)
+					{
+						CheckAndRemoveCrc(crcInLittleEndian);
+					}
+					return true;
+				case BL_DLE:
+					mLastWasDLE = true;
+					break;
+				case BL_STX:
+					Trace(ZONE_INFO, "Detect STX\n");
+					Clear();
+					break;
+				default:
+					Add(*pInput);
+					break;
+			}
+		}
+		pInput++;
+	}
+	return false;
+}
+
+void UnmaskBuffer::AddToCrc(uint8_t newByte)
+{
+	mPrePreCrc = mPreCrc;
+	mPreCrc = mCrc;
+	Crc_AddCrc16(newByte, &mCrc);
+}
+
+uint16_t UnmaskBuffer::GetCrc16(bool crcInLittleEndian) const
+{
+	if(crcInLittleEndian)
+	{
+		uint16_t crc = mPrePreCrc;
+		Crc_AddCrc16(mData[mLength-1], &crc);
+		Crc_AddCrc16(mData[mLength-2], &crc);
+		return crc;
+	}
+	return mCrc;
+}

--- a/library/WiflyControl.cpp
+++ b/library/WiflyControl.cpp
@@ -53,7 +53,6 @@ static const int g_DebugZones = ZONE_ERROR | ZONE_WARNING | ZONE_INFO | ZONE_VER
 }
 
 const std::string WiflyControl::LEDS_ALL{"ffffffff"};
-const double WiflyControl::CALIBRATION_VALUE{19.1};
 
 WiflyControl::WiflyControl(uint32_t addr, uint16_t port)
 : mSock(addr, port), mProxy(mSock), mTelnet(mSock)
@@ -631,19 +630,16 @@ void WiflyControl::FwSetColorDirect(WiflyResponse& response, unsigned char* pBuf
 	FwSend(&mCmdFrame, sizeof(struct cmd_set_color_direct),response);
 }
 
-void WiflyControl::FwSetFade(WiflyResponse& response, uint32_t argb, uint32_t fadeTmms, uint32_t addr, bool parallelFade)
+void WiflyControl::FwSetFade(WiflyResponse& response, uint32_t argb, uint16_t fadeTmms, uint32_t addr, bool parallelFade)
 {
-	fadeTmms = fadeTmms / CALIBRATION_VALUE;
-	if(fadeTmms < 4) fadeTmms = 4;
-	
 	mCmdFrame.led.cmd = SET_FADE;
 	SetAddrRgb(mCmdFrame.led.data.set_fade, addr, argb);
-	mCmdFrame.led.data.set_fade.fadeTmms = htons((uint16_t)fadeTmms);
+	mCmdFrame.led.data.set_fade.fadeTmms = htons(fadeTmms);
 	mCmdFrame.led.data.set_fade.parallelFade = parallelFade;
 	FwSend(&mCmdFrame, sizeof(cmd_set_fade), response);
 }
 
-void WiflyControl::FwSetFade(WiflyResponse& response, const string& rgb, uint32_t fadeTmms, const string& addr, bool parallelFade)
+void WiflyControl::FwSetFade(WiflyResponse& response, const string& rgb, uint16_t fadeTmms, const string& addr, bool parallelFade)
 {
 	FwSetFade(response, 0xff000000 | WiflyColor::ToARGB(rgb), fadeTmms, WiflyColor::ToARGB(addr), parallelFade);
 }
@@ -664,10 +660,10 @@ void WiflyControl::FwSetRtc(SimpleResponse& response, struct tm* timeValue)
 	FwSend(&mCmdFrame, sizeof(struct rtc_time),response);
 }
 
-void WiflyControl::FwSetWait(WiflyResponse& response, uint32_t waitTmms)
+void WiflyControl::FwSetWait(WiflyResponse& response, uint16_t waitTmms)
 {
 	mCmdFrame.led.cmd = WAIT;
-	mCmdFrame.led.data.wait.waitTmms = htons((uint16_t)(waitTmms / CALIBRATION_VALUE));
+	mCmdFrame.led.data.wait.waitTmms = htons(waitTmms);
 	
 	FwSend(&mCmdFrame, sizeof(cmd_set_fade), response);
 }

--- a/library/WiflyControl.cpp
+++ b/library/WiflyControl.cpp
@@ -632,6 +632,8 @@ void WiflyControl::FwSetColorDirect(WiflyResponse& response, unsigned char* pBuf
 
 void WiflyControl::FwSetFade(WiflyResponse& response, uint32_t argb, uint16_t fadeTmms, uint32_t addr, bool parallelFade)
 {
+	if (fadeTmms < 1) fadeTmms = 1;
+		
 	mCmdFrame.led.cmd = SET_FADE;
 	SetAddrRgb(mCmdFrame.led.data.set_fade, addr, argb);
 	mCmdFrame.led.data.set_fade.fadeTmms = htons(fadeTmms);

--- a/library/WiflyControl.h
+++ b/library/WiflyControl.h
@@ -234,7 +234,7 @@ class WiflyControl
 		 * @param addr bitmask of leds which should be effected by this command, set bit to 1 to affect the led, default 0xffffffff
 		 * @param parallelFade if true other fades are allowed in parallel with this fade
 		 */
-		void FwSetFade(WiflyResponse& response, uint32_t argb, uint32_t fadeTmms = 0, uint32_t addr = 0xffffffff, bool parallelFade = false);
+		void FwSetFade(WiflyResponse& response, uint32_t argb, uint16_t fadeTmms = 0, uint32_t addr = 0xffffffff, bool parallelFade = false);
 
 		/**
 		 * Injects a fade command into the wifly script controller
@@ -250,7 +250,7 @@ class WiflyControl
 		 *        only the last led "80000000"
 		 * @param parallelFade if true other fades are allowed in parallel with this fade
 		 */
-		void FwSetFade(WiflyResponse& response, const std::string& rgb, uint32_t fadeTmms = 0, const std::string& addr = LEDS_ALL, bool parallelFade = false);
+		void FwSetFade(WiflyResponse& response, const std::string& rgb, uint16_t fadeTmms = 0, const std::string& addr = LEDS_ALL, bool parallelFade = false);
 
 		/**
 		 * Sets the rtc clock of the wifly device to the specified time.
@@ -266,7 +266,7 @@ class WiflyControl
 		 * @param response will be modified according to the success of this operation
 		 * @param waitTmms timme in milliseconds to wait until execution of the next command
 		 */
-		void FwSetWait(WiflyResponse& response, uint32_t waitTmms);
+		void FwSetWait(WiflyResponse& response, uint16_t waitTmms);
 
 		/**
 		 * Stops firmware and script controller execution and start the bootloader of the wifly device
@@ -289,11 +289,6 @@ class WiflyControl
 
 /* ------------------------- PRIVATE DECLARATIONS ------------------------- */
 	private:
-		/**
-		 * Internal calculation value to convert a given timevalue to the right value for the Wifly_Light. This value is used in every functions with expectes a Tmms value as parameter.
-		 */
-		static const double CALIBRATION_VALUE;
-
 		/**
 		 * Socket used for communication with wifly device.
 		 * A reference to this socket is provided to the aggregated subobjects.

--- a/library/WiflyControl_ut.cpp
+++ b/library/WiflyControl_ut.cpp
@@ -516,7 +516,7 @@ size_t ut_WiflyControl_FwSetFade(void)
 	expectedOutgoingFrame.led.data.set_fade.blue = 0xff;
 	expectedOutgoingFrame.led.data.set_fade.parallelFade = 0x00;
 	//TODO why do we use fadeTmms == 1 for SetColor?
-	expectedOutgoingFrame.led.data.set_fade.fadeTmms = htons(0x0004);
+	expectedOutgoingFrame.led.data.set_fade.fadeTmms = htons(0x0001);
 
 	TestCaseBegin();
 	WiflyControl testee(0, 0);


### PR DESCRIPTION
- completed exception handling for firmware functions of WiflyControl
- begun exception harmonization of bootloader functions of WiflyControl

Something to keep in mind:
I think Trace(bla) followed by an Exception(bla) is redundant. if we throw an exception we dont need any trace.If we need more detailed information on where the exception occurred we have to add that information to the exception. I will remove these kind of redundancy when refactoring the Bootloader functions.
