### PR TITLE
usage of std::function to replace SolveExceptions()

### DIFF
--- a/android/WiflyLight/jni/Android.mk
+++ b/android/WiflyLight/jni/Android.mk
@@ -13,6 +13,7 @@ LOCAL_SRC_FILES += $(LIB_SRC)intelhexclass.cpp
 LOCAL_SRC_FILES += $(LIB_SRC)MaskBuffer.cpp
 LOCAL_SRC_FILES += $(LIB_SRC)TelnetProxy.cpp
 LOCAL_SRC_FILES += $(LIB_SRC)WiflyControl.cpp
+LOCAL_SRC_FILES += $(LIB_SRC)WiflyControlNoThrow.cpp
 LOCAL_SRC_FILES += WiflyControlJni.cpp
 LOCAL_C_INCLUDES += $(LOCAL_PATH)/c++11_wrapper
 LOCAL_C_INCLUDES += $(LOCAL_PATH)/$(FW_SRC)

--- a/firmware/unittest.h
+++ b/firmware/unittest.h
@@ -52,7 +52,7 @@
 
 #define UnitTestMainBegin(X) int numErrors = 0; int numSkipped = 0; int numTests = 0;
 #define UnitTestMainEnd(X) { \
-	printf("%25s run %2d Tests (%2d skipped | %2d errors)\n", __FILE__, numTests, numSkipped, numErrors); \
+	printf("%26s run %2d Tests (%2d skipped | %2d errors)\n", __FILE__, numTests, numSkipped, numErrors); \
 	return numErrors; \
 }
 

--- a/library/WiflyControl.cpp
+++ b/library/WiflyControl.cpp
@@ -91,15 +91,15 @@ void WiflyControl::BlEraseFlash(void) const throw(ConnectionTimeout, FatalError)
 
 	while(address > FLASH_ERASE_BLOCKSIZE * FLASH_ERASE_BLOCKS)
 	{
-		BlEraseFlash(address, FLASH_ERASE_BLOCKS);
+		BlEraseFlashArea(address, FLASH_ERASE_BLOCKS);
 		address -= FLASH_ERASE_BLOCKSIZE * FLASH_ERASE_BLOCKS;
 	}
 	/* now we erased everything until a part of the flash smaller than FLASH_ERASE_BLOCKS * FLASH_ERASE_BLOCKSIZE
 	 * so we set our startaddress at the beginning of this block and erase */
-	BlEraseFlash(FLASH_ERASE_BLOCKS * FLASH_ERASE_BLOCKSIZE -1, FLASH_ERASE_BLOCKS);
+	BlEraseFlashArea(FLASH_ERASE_BLOCKS * FLASH_ERASE_BLOCKSIZE -1, FLASH_ERASE_BLOCKS);
 }
 
-void WiflyControl::BlEraseFlash(const uint32_t endAddress, const uint8_t numPages) const throw(ConnectionTimeout, FatalError)
+void WiflyControl::BlEraseFlashArea(const uint32_t endAddress, const uint8_t numPages) const throw(ConnectionTimeout, FatalError)
 {
 	unsigned char response;
 	BlFlashEraseRequest request(endAddress, numPages);

--- a/library/WiflyControl.h
+++ b/library/WiflyControl.h
@@ -368,7 +368,7 @@ class WiflyControl
 		 * @throw ConnectionTimeout if response timed out
 		 * @throw FatalError if command code of the response doesn't match the code of the request, or too many retries failed
 		 */
-		void BlEraseFlash(const uint32_t endAddress, const uint8_t numPages) const throw (ConnectionTimeout, FatalError);
+		void BlEraseFlashArea(const uint32_t endAddress, const uint8_t numPages) const throw (ConnectionTimeout, FatalError);
 
 		/**
 		 * Send a request to the bootloader and read his response into pResponse

--- a/library/WiflyControlNoThrow.h
+++ b/library/WiflyControlNoThrow.h
@@ -19,28 +19,7 @@
 #ifndef _WIFLYCONTROL_NOTHROW_H_
 #define _WIFLYCONTROL_NOTHROW_H_
 #include "WiflyControl.h"
-
-/******************************************************************************/
-/*!\file WiflyControlNoThrow.h
- * \author Nils Weiss, Patrick Bruenn
- *
- * \cond
- * enum - WiflyError
- * \endcond
- *
- * \brief Returnvalues of WiflyControlNoThrow
- *
- *
- *******************************************************************************/
-
-enum WiflyError {
-	NO_ERROR = 0,			/**< is returned if no error occurred */ 
-	FATAL_ERROR,			/**< if command code of the response doesn't match the code of the request, or too many retries failed */ 
-	CONNECTION_LOST,
-	CONNECTION_TIMEOUT,		/**< if response timed out */
-	INVALID_PARAMETER,		/**< if a parameter is out of bound */
-	SCRIPT_FULL,
-};
+#include <functional>
 
 /******************************************************************************/
 /*!\cond
@@ -366,6 +345,6 @@ class WiflyControlNoThrow : private WiflyControl
 		 * Converts all exceptions from ::WiflyControl to the relating ::WiflyError
 		 */
 		uint32_t SolveException(void) const;
-	
+		uint32_t Try(const std::function<void(const WiflyControl&)> call) const;
 };
 #endif /* #ifndef _WIFLYCONTROL_NOTHROW_H_ */


### PR DESCRIPTION
...id)const function

implement FatalError::AsErrorCode() to bind the ErrorCodes closer to the exceptions, which saves some lines of code too

Todo:
- make WiflyControl::FwSend() const, when using FwRequest as a parameter so we can use our new WiflyControlNoThrow::Try() for the firmware functions too. Else we had to writte an overloader Try() for that purpose
- add some overloades to Try() to support other functions with different parameters, research if va_args or variadic templates can help here
