### PR TITLE
Recent connections support for BroadcastReceiver

### DIFF
--- a/android/WiflyLight/AndroidManifest.xml
+++ b/android/WiflyLight/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="biz.bruenn.WiflyLight"
-    android:versionCode="6"
-    android:versionName="0.6" >
+    android:versionCode="7"
+    android:versionName="0.7" >
 
     <uses-sdk android:minSdkVersion="8" />
 

--- a/android/WiflyLight/jni/WiflyControlJni.cpp
+++ b/android/WiflyLight/jni/WiflyControlJni.cpp
@@ -37,9 +37,12 @@ void ThrowJniException(JNIEnv* env, const FatalError& e) {
 	}
 
 extern "C" {
-jlong Java_biz_bruenn_WiflyLight_RemoteCollector_createBroadcastReceiver(JNIEnv* env, jobject ref)
+jlong Java_biz_bruenn_WiflyLight_RemoteCollector_createBroadcastReceiver(JNIEnv* env, jobject ref, jstring path)
 {
-	return (jlong) new BroadcastReceiver(BroadcastReceiver::BROADCAST_PORT);
+	const char* myPath = env->GetStringUTFChars(path, 0);
+	const jlong result = (jlong) new BroadcastReceiver(myPath, BroadcastReceiver::BROADCAST_PORT);
+	env->ReleaseStringUTFChars(path, myPath);
+	return result;
 }
 
 void Java_biz_bruenn_WiflyLight_RemoteCollector_releaseBroadcastReceiver(JNIEnv* env, jobject ref, jlong pNative)

--- a/android/WiflyLight/jni/WiflyControlJni.cpp
+++ b/android/WiflyLight/jni/WiflyControlJni.cpp
@@ -40,7 +40,7 @@ extern "C" {
 jlong Java_biz_bruenn_WiflyLight_RemoteCollector_createBroadcastReceiver(JNIEnv* env, jobject ref, jstring path)
 {
 	const char* myPath = env->GetStringUTFChars(path, 0);
-	const jlong result = (jlong) new BroadcastReceiver(myPath, BroadcastReceiver::BROADCAST_PORT);
+	const jlong result = (jlong) new BroadcastReceiver(BroadcastReceiver::BROADCAST_PORT, myPath);
 	env->ReleaseStringUTFChars(path, myPath);
 	return result;
 }

--- a/android/WiflyLight/jni/WiflyControlJni.cpp
+++ b/android/WiflyLight/jni/WiflyControlJni.cpp
@@ -21,7 +21,8 @@
 #include <unistd.h>
 #include <jni.h>
 
-static WiflyControl* g_pControl = NULL;
+namespace WyLight {
+static Control* g_pControl = NULL;
 
 void ThrowJniException(JNIEnv* env, const FatalError& e) {
 		jclass javaException = env->FindClass(e.GetJavaClassType());
@@ -60,7 +61,7 @@ jlong Java_biz_bruenn_WiflyLight_WiflyControl_create(JNIEnv* env, jobject ref, j
 	// TODO make this threadsafe
 	if(NULL == g_pControl) {
 		try {
-			g_pControl = new WiflyControl(ipv4Addr, port);
+			g_pControl = new Control(ipv4Addr, port);
 			return reinterpret_cast<jlong>(g_pControl);
 		} catch (FatalError& e) {
 			g_pControl = NULL;
@@ -72,7 +73,7 @@ jlong Java_biz_bruenn_WiflyLight_WiflyControl_create(JNIEnv* env, jobject ref, j
 
 jstring Java_biz_bruenn_WiflyLight_WiflyControl_ConfGetSsid(JNIEnv* env, jobject ref, jlong pNative)
 {
-	std::string mySsid = reinterpret_cast<WiflyControl*>(pNative)->ConfGetSsid();
+	std::string mySsid = reinterpret_cast<Control*>(pNative)->ConfGetSsid();
 	return env->NewStringUTF(mySsid.data());
 }
 
@@ -80,7 +81,7 @@ jboolean Java_biz_bruenn_WiflyLight_WiflyControl_ConfSetWlan(JNIEnv* env, jobjec
 {
 	const char* myPassphrase = env->GetStringUTFChars(passphrase, 0);
 	const char* mySsid = env->GetStringUTFChars(ssid, 0);
-	jboolean result = reinterpret_cast<WiflyControl*>(pNative)->ConfSetWlan(myPassphrase, mySsid);
+	jboolean result = reinterpret_cast<Control*>(pNative)->ConfModuleForWlan(myPassphrase, mySsid);
 	env->ReleaseStringUTFChars(passphrase, myPassphrase);
 	env->ReleaseStringUTFChars(ssid, mySsid);
 	return result;
@@ -88,35 +89,36 @@ jboolean Java_biz_bruenn_WiflyLight_WiflyControl_ConfSetWlan(JNIEnv* env, jobjec
 
 jboolean Java_biz_bruenn_WiflyLight_WiflyControl_FwClearScript(JNIEnv* env, jobject ref, jlong pNative)
 {
-	TRY_CATCH_RETURN_BOOL(reinterpret_cast<WiflyControl*>(pNative)->FwClearScript());
+	TRY_CATCH_RETURN_BOOL(reinterpret_cast<Control*>(pNative)->FwClearScript());
 }
 
 jboolean Java_biz_bruenn_WiflyLight_WiflyControl_FwLoopOff(JNIEnv* env, jobject ref, jlong pNative, jbyte numLoops)
 {
-	TRY_CATCH_RETURN_BOOL(reinterpret_cast<WiflyControl*>(pNative)->FwLoopOff(numLoops));
+	TRY_CATCH_RETURN_BOOL(reinterpret_cast<Control*>(pNative)->FwLoopOff(numLoops));
 }
 
 jboolean Java_biz_bruenn_WiflyLight_WiflyControl_FwLoopOn(JNIEnv* env, jobject ref, jlong pNative)
 {
-	TRY_CATCH_RETURN_BOOL(reinterpret_cast<WiflyControl*>(pNative)->FwLoopOn());
+	TRY_CATCH_RETURN_BOOL(reinterpret_cast<Control*>(pNative)->FwLoopOn());
 }
 
 jboolean Java_biz_bruenn_WiflyLight_WiflyControl_FwSetColor(JNIEnv* env, jobject ref, jlong pNative, jint argb, jint addr)
 {
-	TRY_CATCH_RETURN_BOOL(reinterpret_cast<WiflyControl*>(pNative)->FwSetFade(argb, 0, addr, false));
+	TRY_CATCH_RETURN_BOOL(reinterpret_cast<Control*>(pNative)->FwSetFade(argb, 0, addr, false));
 }
 
 jboolean Java_biz_bruenn_WiflyLight_WiflyControl_FwSetFade(JNIEnv* env, jobject ref, jlong pNative, jint argb, jint addr, jshort fadeTime)
 {
-	TRY_CATCH_RETURN_BOOL(reinterpret_cast<WiflyControl*>(pNative)->FwSetFade(argb, fadeTime, addr, false));
+	TRY_CATCH_RETURN_BOOL(reinterpret_cast<Control*>(pNative)->FwSetFade(argb, fadeTime, addr, false));
 }
 
 void Java_biz_bruenn_WiflyLight_WiflyControl_release(JNIEnv* env, jobject ref, jlong pNative)
 {
-	if((WiflyControl*)pNative == g_pControl) {
+	if((Control*)pNative == g_pControl) {
 		delete g_pControl;
 		g_pControl = NULL;
 	}
 }
 }
+} /* namespace WyLight */
 

--- a/android/WiflyLight/src/biz/bruenn/WiflyLight/BroadcastReceiver.java
+++ b/android/WiflyLight/src/biz/bruenn/WiflyLight/BroadcastReceiver.java
@@ -1,0 +1,30 @@
+package biz.bruenn.WiflyLight;
+
+public class BroadcastReceiver {
+	private native long create(String path);
+	private native long getEndpoint(long pNative, long index);
+	private native long getNextRemote(long pNative, long timeoutNanos);
+	private native void release(long pNative);
+	
+	private long mNative = 0;
+	
+	public BroadcastReceiver(String recentFilename) {
+		mNative = create(recentFilename);
+	}
+	
+	public Endpoint getEndpoint(long index) {
+		return new Endpoint(mNative, getEndpoint(mNative, index));
+	}
+	
+	public final long getNative() {
+		return mNative;
+	}
+	
+	public Endpoint getNextRemote(long timeoutNanos) {
+		return new Endpoint(mNative, getNextRemote(mNative, timeoutNanos));
+	}
+	
+	public void release() {
+		release(mNative);
+	}
+}

--- a/android/WiflyLight/src/biz/bruenn/WiflyLight/Endpoint.java
+++ b/android/WiflyLight/src/biz/bruenn/WiflyLight/Endpoint.java
@@ -2,22 +2,37 @@ package biz.bruenn.WiflyLight;
 
 import java.io.Serializable;
 
+import biz.bruenn.WiflyLight.exception.FatalError;
+
 public class Endpoint implements Serializable {
 	private static final long serialVersionUID = -8653676704955283379L;
+
+	private native long connect(long pBroadcastReceiver, long fingerprint) throws FatalError;
+	
 	private final int mAddr;
 	private final short mPort;
+	private final long mParentBroadcastReceiver;
 	
-	public Endpoint(int addr, short port) {
+	public Endpoint(long parent, int addr, short port) {
 		mAddr = addr;
 		mPort = port;
+		mParentBroadcastReceiver = parent;
 	}
 	
-	public Endpoint(long remote) {
-		this((int)(remote >> 32), (short)(remote & 0x000000000000ffffL));
+	public Endpoint(long parent, long fingerprint) {
+		this(parent, (int)(fingerprint >> 32), (short)(fingerprint & 0x000000000000ffffL));
+	}
+	
+	public long connect() throws FatalError {
+		return connect(mParentBroadcastReceiver, getFingerprint());
 	}
 
 	public int getAddr() {
 		return mAddr;
+	}
+	
+	public long getFingerprint() {
+		return (((long)mAddr) << 32) | ((long)mPort);
 	}
 	
 	public short getPort() {

--- a/android/WiflyLight/src/biz/bruenn/WiflyLight/Endpoint.java
+++ b/android/WiflyLight/src/biz/bruenn/WiflyLight/Endpoint.java
@@ -15,7 +15,7 @@ public class Endpoint implements Serializable {
 	public Endpoint(long remote) {
 		this((int)(remote >> 32), (short)(remote & 0x000000000000ffffL));
 	}
-	
+
 	public int getAddr() {
 		return mAddr;
 	}

--- a/android/WiflyLight/src/biz/bruenn/WiflyLight/RemoteCollector.java
+++ b/android/WiflyLight/src/biz/bruenn/WiflyLight/RemoteCollector.java
@@ -3,33 +3,25 @@ package biz.bruenn.WiflyLight;
 import java.util.ArrayList;
 import biz.bruenn.WiflyLight.R.string;
 
-import android.content.Context;
 import android.net.wifi.WifiManager;
 import android.os.AsyncTask;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
 
 public class RemoteCollector extends AsyncTask<Long, Void, Void> {
-	private native long createBroadcastReceiver(String path);
-	private native long getNextRemote(long pNative, long timeoutNanos);
-	private native void releaseBroadcastReceiver(long pNative);
 	
 	private ArrayAdapter<Endpoint> mRemoteArrayAdapter;
 	private ArrayList<Endpoint> mRemoteArray;
-	private WifiManager.MulticastLock mMulticastLock; 
-	private long mNative = 0;
+	private WifiManager.MulticastLock mMulticastLock;
+	private BroadcastReceiver mBroadcastReceiver;
 	private Button mScanBtn;
 	
-	public RemoteCollector(Context context, WifiManager wifiMgr, ArrayList<Endpoint> remoteArray, ArrayAdapter<Endpoint> remoteArrayAdapter, Button scanBtn) {
+	public RemoteCollector(BroadcastReceiver receiver, WifiManager wifiMgr, ArrayList<Endpoint> remoteArray, ArrayAdapter<Endpoint> remoteArrayAdapter, Button scanBtn) {
 		mMulticastLock = wifiMgr.createMulticastLock("WiflyLight_MulticastLock");
-		mNative = createBroadcastReceiver(context.getFilesDir().getAbsolutePath());
+		mBroadcastReceiver = receiver;
 		mRemoteArray = remoteArray;
 		mRemoteArrayAdapter = remoteArrayAdapter;
 		mScanBtn = scanBtn;
-	}
-	
-	public void finalize() throws Throwable {
-		releaseBroadcastReceiver(mNative);
 	}
 
 	public void run() {
@@ -42,7 +34,7 @@ public class RemoteCollector extends AsyncTask<Long, Void, Void> {
 		
 		mMulticastLock.acquire();
 		while(!isCancelled() && (timeoutNanos > 0)) {
-			Endpoint remote = new Endpoint(getNextRemote(mNative, timeoutNanos));
+			Endpoint remote = mBroadcastReceiver.getNextRemote(timeoutNanos);
 			
 			if(remote.isValid())
 			{

--- a/android/WiflyLight/src/biz/bruenn/WiflyLight/RemoteCollector.java
+++ b/android/WiflyLight/src/biz/bruenn/WiflyLight/RemoteCollector.java
@@ -3,13 +3,14 @@ package biz.bruenn.WiflyLight;
 import java.util.ArrayList;
 import biz.bruenn.WiflyLight.R.string;
 
+import android.content.Context;
 import android.net.wifi.WifiManager;
 import android.os.AsyncTask;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
 
 public class RemoteCollector extends AsyncTask<Long, Void, Void> {
-	private native long createBroadcastReceiver();
+	private native long createBroadcastReceiver(String path);
 	private native long getNextRemote(long pNative, long timeoutNanos);
 	private native void releaseBroadcastReceiver(long pNative);
 	
@@ -19,9 +20,9 @@ public class RemoteCollector extends AsyncTask<Long, Void, Void> {
 	private long mNative = 0;
 	private Button mScanBtn;
 	
-	public RemoteCollector(WifiManager wifiMgr, ArrayList<Endpoint> remoteArray, ArrayAdapter<Endpoint> remoteArrayAdapter, Button scanBtn) {
+	public RemoteCollector(Context context, WifiManager wifiMgr, ArrayList<Endpoint> remoteArray, ArrayAdapter<Endpoint> remoteArrayAdapter, Button scanBtn) {
 		mMulticastLock = wifiMgr.createMulticastLock("WiflyLight_MulticastLock");
-		mNative = createBroadcastReceiver();
+		mNative = createBroadcastReceiver(context.getFilesDir().getAbsolutePath());
 		mRemoteArray = remoteArray;
 		mRemoteArrayAdapter = remoteArrayAdapter;
 		mScanBtn = scanBtn;

--- a/android/WiflyLight/src/biz/bruenn/WiflyLight/WiflyControl.java
+++ b/android/WiflyLight/src/biz/bruenn/WiflyLight/WiflyControl.java
@@ -8,7 +8,6 @@ public class WiflyControl {
 	
 	public static final int ALL_LEDS = 0xffffffff;
 	
-	private native long create(int ipv4Addr, short port) throws FatalError;
 	private native String ConfGetSsid(long pNative);
 	private native boolean ConfSetWlan(long pNative, String passphrase, String ssid);
 	private native boolean FwClearScript(long pNative);
@@ -25,7 +24,7 @@ public class WiflyControl {
 	}
 	
 	public synchronized boolean connect(Endpoint remote) throws FatalError {
-		mNative = create(remote.getAddr(), remote.getPort());
+		mNative = remote.connect();
 		return 0 != mNative;
 	}
 	

--- a/android/WiflyLight/src/biz/bruenn/WiflyLight/WiflyLightActivity.java
+++ b/android/WiflyLight/src/biz/bruenn/WiflyLight/WiflyLightActivity.java
@@ -21,9 +21,10 @@ import android.widget.ListView;
 import android.widget.TextView;
 
 public class WiflyLightActivity extends Activity {
-	private ListView mRemoteList;
 	private ArrayList<Endpoint> mRemoteArray = new ArrayList<Endpoint>();
 	private ArrayAdapter<Endpoint> mRemoteArrayAdapter;
+	private ListView mRemoteList;
+	private RemoteManager mRemoteManager;
 	
 	static {
 		System.loadLibrary("wifly");
@@ -58,12 +59,16 @@ public class WiflyLightActivity extends Activity {
 				Button btn = (Button)v;
 				btn.setClickable(false);
 				btn.setText(string.scanning);
-				new RemoteCollector((WifiManager)getSystemService(Context.WIFI_SERVICE), 
+				new RemoteCollector(v.getContext(), (WifiManager)getSystemService(Context.WIFI_SERVICE), 
 						mRemoteArray,
 						mRemoteArrayAdapter,
 						btn).execute(Long.valueOf(3000000000L));
 			}
 		});
+        
+        mRemoteManager = new RemoteManager(this);
+        //mRemoteManager.addFavouritesToList(mRemoteArray);
+        //mRemoteArrayAdapter.notifyDataSetChanged();
     }
     
     @Override

--- a/cli/WiflyControlCli.cpp
+++ b/cli/WiflyControlCli.cpp
@@ -80,33 +80,25 @@ void WiflyControlCli::ShowHelp(void) const
 	return;
 }
 
+void newRemoteCallback(const size_t index, const WyLight::Endpoint& newEndpoint)
+{
+	std::cout << "New: " << index << ':' << newEndpoint << '\n';
+}
+
 int main(int argc, const char* argv[])
 {
 	WyLight::BroadcastReceiver receiver(55555);
+	receiver.SetCallbackAddedNewRemote(newRemoteCallback);
 	std::stringstream logStream;
 	std::thread t(std::ref(receiver), std::ref(logStream));
 
 	// wait for user input
-	size_t selection;
-	std::thread u([&]
-	{
-		size_t numOfRemotes = 0;
-		while(selection >= receiver.NumRemotes())
-		{
-			sleep(1);
-			if(numOfRemotes != receiver.NumRemotes())
-			{
-				numOfRemotes = receiver.NumRemotes();
-				for(int i = 0; i < 100; i++) cout << endl;
-				receiver.PrintAllEndpoints(cout);
-	}}});
-	
+	size_t selection;	
 	do
 	{
 		std::cin >> selection;
 	} while(selection >= receiver.NumRemotes());
 	
-	u.join();
 	receiver.Stop();
 	t.join();
 	

--- a/cli/WiflyControlCli.cpp
+++ b/cli/WiflyControlCli.cpp
@@ -87,10 +87,8 @@ void newRemoteCallback(const size_t index, const WyLight::Endpoint& newEndpoint)
 
 int main(int argc, const char* argv[])
 {
-	WyLight::BroadcastReceiver receiver(55555);
-	receiver.SetCallbackAddedNewRemote(newRemoteCallback);
-	std::stringstream logStream;
-	std::thread t(std::ref(receiver), std::ref(logStream));
+	WyLight::BroadcastReceiver receiver(55555, "recent.txt", newRemoteCallback);
+	std::thread t(std::ref(receiver));
 
 	// wait for user input
 	size_t selection;	

--- a/library/BroadcastReceiver.cpp
+++ b/library/BroadcastReceiver.cpp
@@ -31,7 +31,7 @@ const std::string BroadcastReceiver::DEVICE_ID("Wifly_Light");
 const std::string BroadcastReceiver::DEVICE_ID_OLD("WiFly");
 const std::string BroadcastReceiver::DEVICE_VERSION("WiFly Ver 2.45, 10-09-2012");
 const std::string BroadcastReceiver::STOP_MSG{"StopThread"};
-const Endpoint BroadcastReceiver::EMPTY_ENDPOINT;
+Endpoint BroadcastReceiver::EMPTY_ENDPOINT{};
 
 BroadcastReceiver::BroadcastReceiver(uint16_t port, const std::string& recentFilename)
 	: mPort(port), mIsRunning(true), mNumInstances(0), mRecentFilename(recentFilename)
@@ -86,7 +86,18 @@ void BroadcastReceiver::PrintAllEndpoints(std::ostream& out)
 
 Endpoint& BroadcastReceiver::GetEndpoint(size_t index)
 {
-	return mIpTable[index];
+	auto it = mIpTable.find(index);
+	return (mIpTable.end() == it) ? EMPTY_ENDPOINT : it->second;
+}
+
+Endpoint& BroadcastReceiver::GetEndpointByFingerprint(const uint64_t fingerprint)
+{
+	for(auto it = mIpTable.begin(); it != mIpTable.end(); it++) {
+		if(fingerprint == (*it).second.AsUint64()) {
+			return (*it).second;
+		}
+	}
+	return EMPTY_ENDPOINT;
 }
 
 Endpoint BroadcastReceiver::GetNextRemote(timeval* timeout) throw (FatalError)

--- a/library/BroadcastReceiver.cpp
+++ b/library/BroadcastReceiver.cpp
@@ -32,7 +32,13 @@ const std::string WyLight::BroadcastReceiver::STOP_MSG{"StopThread"};
 const WyLight::Endpoint WyLight::BroadcastReceiver::EMPTY_ENDPOINT;
 
 WyLight::BroadcastReceiver::BroadcastReceiver(uint16_t port)
+
+#if defined(__cplusplus) && (__cplusplus < 201103L)
+#warning "Check for a newer compiler to avoid using this C++11 wrapper file"
+	: mPort(port), mIsRunning(true), mNumInstances(0), mAddedNewRemoteCallback(NULL)
+#else
 	: mPort(port), mIsRunning(true), mNumInstances(0), mAddedNewRemoteCallback(nullptr)
+#endif
 {
 }
 

--- a/library/BroadcastReceiver.cpp
+++ b/library/BroadcastReceiver.cpp
@@ -67,9 +67,10 @@ void BroadcastReceiver::operator() (std::ostream& out, timeval* pTimeout)
 		{
 			const Endpoint remote = GetNextRemote(pTimeout);
 			if(remote.IsValid()) {
-				out << numRemotes << ':' << remote << '\n';
+				if(mAddedNewRemoteCallback) {
+					mAddedNewRemoteCallback(numRemotes, remote);
+				}
 				numRemotes++;
-				if(mAddedNewRemoteCallback) mAddedNewRemoteCallback(remote);
 			}
 			gettimeofday(&now, NULL);
 		} while(mIsRunning && timeval_sub(&endTime, &now, pTimeout));
@@ -158,7 +159,7 @@ void BroadcastReceiver::ReadRecentEndpoints(const std::string& filename)
 	inFile.close();
 }
 
-void BroadcastReceiver::SetCallbackAddedNewRemote(const std::function<void(const Endpoint& newEndpoint)>& functionObj)
+void BroadcastReceiver::SetCallbackAddedNewRemote(const std::function<void(size_t index, const Endpoint& newEndpoint)>& functionObj)
 {
 	mAddedNewRemoteCallback = functionObj;
 }

--- a/library/BroadcastReceiver.cpp
+++ b/library/BroadcastReceiver.cpp
@@ -33,14 +33,16 @@ const std::string BroadcastReceiver::DEVICE_VERSION("WiFly Ver 2.45, 10-09-2012"
 const std::string BroadcastReceiver::STOP_MSG{"StopThread"};
 const Endpoint BroadcastReceiver::EMPTY_ENDPOINT;
 
-BroadcastReceiver::BroadcastReceiver(uint16_t port)
-	: mPort(port), mIsRunning(true), mNumInstances(0)
+BroadcastReceiver::BroadcastReceiver(uint16_t port, const std::string& recentFilename)
+	: mPort(port), mIsRunning(true), mNumInstances(0), mRecentFilename(recentFilename)
 {
+	ReadRecentEndpoints(mRecentFilename);
 }
 
 BroadcastReceiver::~BroadcastReceiver(void)
 {
 	Stop();
+	WriteRecentEndpoints(mRecentFilename);
 }
 
 void BroadcastReceiver::operator() (std::ostream& out, timeval* pTimeout)

--- a/library/BroadcastReceiver.cpp
+++ b/library/BroadcastReceiver.cpp
@@ -23,15 +23,17 @@
 #include <iostream>
 #include <stdio.h>
 
+namespace WyLight {
+
 static const int g_DebugZones = ZONE_ERROR | ZONE_WARNING | ZONE_INFO | ZONE_VERBOSE;
 
-const std::string WyLight::BroadcastReceiver::DEVICE_ID("Wifly_Light");
-const std::string WyLight::BroadcastReceiver::DEVICE_ID_OLD("WiFly");
-const std::string WyLight::BroadcastReceiver::DEVICE_VERSION("WiFly Ver 2.45, 10-09-2012");
-const std::string WyLight::BroadcastReceiver::STOP_MSG{"StopThread"};
-const WyLight::Endpoint WyLight::BroadcastReceiver::EMPTY_ENDPOINT;
+const std::string BroadcastReceiver::DEVICE_ID("Wifly_Light");
+const std::string BroadcastReceiver::DEVICE_ID_OLD("WiFly");
+const std::string BroadcastReceiver::DEVICE_VERSION("WiFly Ver 2.45, 10-09-2012");
+const std::string BroadcastReceiver::STOP_MSG{"StopThread"};
+const Endpoint BroadcastReceiver::EMPTY_ENDPOINT;
 
-WyLight::BroadcastReceiver::BroadcastReceiver(uint16_t port)
+BroadcastReceiver::BroadcastReceiver(uint16_t port)
 
 #if defined(__cplusplus) && (__cplusplus < 201103L)
 #warning "Check for a newer compiler to avoid using this C++11 wrapper file"
@@ -42,12 +44,12 @@ WyLight::BroadcastReceiver::BroadcastReceiver(uint16_t port)
 {
 }
 
-WyLight::BroadcastReceiver::~BroadcastReceiver(void)
+BroadcastReceiver::~BroadcastReceiver(void)
 {
 	Stop();
 }
 
-void WyLight::BroadcastReceiver::operator() (std::ostream& out, timeval* pTimeout)
+void BroadcastReceiver::operator() (std::ostream& out, timeval* pTimeout)
 {
 	// only one thread allowed per instance
 	if(0 == std::atomic_fetch_add(&mNumInstances, 1))
@@ -75,7 +77,7 @@ void WyLight::BroadcastReceiver::operator() (std::ostream& out, timeval* pTimeou
 	std::atomic_fetch_sub(&mNumInstances, 1);
 }
 
-void WyLight::BroadcastReceiver::PrintAllEndpoints(std::ostream& out)
+void BroadcastReceiver::PrintAllEndpoints(std::ostream& out)
 {
 	int index = 0;
 	//TODO wait for full c++11 features in android ndk. by the way we should move this printing functions out of BroadcastReceiver into cli or whoever wants to "print" something out
@@ -87,7 +89,7 @@ void WyLight::BroadcastReceiver::PrintAllEndpoints(std::ostream& out)
 	}	
 }
 
-const WyLight::Endpoint& WyLight::BroadcastReceiver::GetEndpoint(size_t index) const
+const Endpoint& BroadcastReceiver::GetEndpoint(size_t index) const
 {
 	if(index >= mIpTable.size())
 		return EMPTY_ENDPOINT;
@@ -97,7 +99,7 @@ const WyLight::Endpoint& WyLight::BroadcastReceiver::GetEndpoint(size_t index) c
 	return *it;
 }
 
-WyLight::Endpoint WyLight::BroadcastReceiver::GetNextRemote(timeval* timeout) throw (FatalError)
+Endpoint BroadcastReceiver::GetNextRemote(timeval* timeout) throw (FatalError)
 {
 	UdpSocket udpSock(INADDR_ANY, mPort, true, 1);
 	sockaddr_storage remoteAddr;
@@ -118,20 +120,20 @@ WyLight::Endpoint WyLight::BroadcastReceiver::GetNextRemote(timeval* timeout) th
 	return Endpoint();
 }
 
-size_t WyLight::BroadcastReceiver::NumRemotes(void) const
+size_t BroadcastReceiver::NumRemotes(void) const
 {
 	return mIpTable.size();
 }
 
-void WyLight::BroadcastReceiver::Stop(void)
+void BroadcastReceiver::Stop(void)
 {
 	mIsRunning = false;
 	UdpSocket sock(INADDR_LOOPBACK, mPort, false);
 	sock.Send((uint8_t*)STOP_MSG.data(), STOP_MSG.size());
 }
 
-void WyLight::BroadcastReceiver::SetCallbackAddedNewRemote(const std::function<void(const Endpoint& newEndpoint)>& functionObj)
+void BroadcastReceiver::SetCallbackAddedNewRemote(const std::function<void(const Endpoint& newEndpoint)>& functionObj)
 {
 	mAddedNewRemoteCallback = functionObj;
 }
-
+} /* namespace WyLight */

--- a/library/BroadcastReceiver.h
+++ b/library/BroadcastReceiver.h
@@ -101,7 +101,7 @@ class BroadcastReceiver
 		/**
 		 * Callback methode to notify that a new Enpoint was add to the IpTable
 		 */
-		void SetCallbackAddedNewRemote(const std::function<void(const Endpoint& newEndpoint)>& functionObj);
+		void SetCallbackAddedNewRemote(const std::function<void(size_t index, const Endpoint& newEndpoint)>& functionObj);
 
 		/**
 		 * Sends a stop event to terminate execution of operator()
@@ -123,7 +123,7 @@ class BroadcastReceiver
 		std::atomic<int32_t> mNumInstances;
 		std::mutex mMutex;
 		const std::string mRecentFilename;
-		std::function<void(const Endpoint& newEndpoint)> mAddedNewRemoteCallback;
+		std::function<void(size_t index, const Endpoint& newEndpoint)> mAddedNewRemoteCallback;
 
 		/**
 		 * Insert threadsafe a new endpoint to the mIpTable

--- a/library/BroadcastReceiver.h
+++ b/library/BroadcastReceiver.h
@@ -25,9 +25,9 @@
 #include <cstring>
 #include <stdint.h>
 #include <string>
+#include <map>
 #include <mutex>
 #include <ostream>
-#include <set>
 #include <string>
 
 class BroadcastReceiver
@@ -39,10 +39,10 @@ class BroadcastReceiver
 		static const std::string DEVICE_VERSION;
 		static const std::string STOP_MSG;
 		static const Endpoint EMPTY_ENDPOINT;
-		const uint16_t mPort;
 
 		/*
 		 * Construct an object for broadcast listening on the specified port
+		 * @param path to the containing files used to store recent remotes
 		 * @param port to listen on, deault is @see BROADCAST_PORT
 		 */
 		BroadcastReceiver(uint16_t port = BROADCAST_PORT);
@@ -64,7 +64,7 @@ class BroadcastReceiver
 		 * @param index of the endpoint in the internal IpTable, should be lees than NumRemotes()
 		 * @return a reference to the endpoint at the specified index or an empty object (@see EMPTY_ENDPOINT), when the index was out of bound
 		 */
-		const Endpoint& GetEndpoint(size_t index) const;
+		Endpoint& GetEndpoint(size_t index);
 
 		/*
 		 * Listen for broadcasts until a new remote is discovered.
@@ -79,18 +79,33 @@ class BroadcastReceiver
 		 */
 		size_t NumRemotes(void) const;
 
+		void PrintAllEndpoints(std::ostream& out);
+
+		/**
+		 * Read recent endpoints from file
+		 * @param filename of the file containing the recent endpoints
+		 */
+		void ReadRecentEndpoints(const std::string& filename);
+
 		/**
 		 * Sends a stop event to terminate execution of operator()
 		 */
 		void Stop(void);
+
+		/**
+		 * Write recent endpoints to file
+		 * @param filename of the file containing the recent endpoints
+		 */
+		void WriteRecentEndpoints(const std::string& filename, uint8_t threshold = 1) const;
 	
-		void PrintAllEndpoints(std::ostream& out);
 
 	private:
-		std::set<Endpoint> mIpTable;
+		const uint16_t mPort;
+		std::map<size_t, Endpoint> mIpTable;
 		volatile bool mIsRunning;
 		std::atomic<int32_t> mNumInstances;
 		std::mutex mMutex;
+		std::string mFavourites;
 };
 #endif /* #ifndef _BROADCAST_RECEIVER_H_ */
 

--- a/library/BroadcastReceiver.h
+++ b/library/BroadcastReceiver.h
@@ -46,7 +46,7 @@ class BroadcastReceiver
 		 * @param path to the containing files used to store recent remotes
 		 * @param port to listen on, deault is @see BROADCAST_PORT
 		 */
-		BroadcastReceiver(uint16_t port = BROADCAST_PORT);
+		BroadcastReceiver(uint16_t port = BROADCAST_PORT, const std::string& recentFilename = "");
 
 		/*
 		 * Stop receiving loop and cleanup
@@ -83,7 +83,7 @@ class BroadcastReceiver
 		void PrintAllEndpoints(std::ostream& out);
 
 		/**
-		 * Read recent endpoints from file
+		 * Read recent endpoints from file and add them to mIpTable
 		 * @param filename of the file containing the recent endpoints
 		 */
 		void ReadRecentEndpoints(const std::string& filename);
@@ -96,6 +96,7 @@ class BroadcastReceiver
 		/**
 		 * Write recent endpoints to file
 		 * @param filename of the file containing the recent endpoints
+		 * @param threshold which an endpoints score has to have at least to be written to the file
 		 */
 		void WriteRecentEndpoints(const std::string& filename, uint8_t threshold = 1) const;
 	
@@ -107,9 +108,14 @@ class BroadcastReceiver
 		volatile bool mIsRunning;
 		std::atomic<int32_t> mNumInstances;
 		std::mutex mMutex;
-		std::string mFavourites;
+		const std::string mRecentFilename;
 
-		bool LockedInsert(Endpoint& e);
+		/**
+		 * Insert threadsafe a new endpoint to the mIpTable
+		 * @param endpoint a copy of this referenced object will be stored to mIpTable
+		 * @return true if a new endpoint was added, false if it already existed or an error occur
+		 */
+		bool LockedInsert(Endpoint& endpoint);
 };
 #endif /* #ifndef _BROADCAST_RECEIVER_H_ */
 

--- a/library/BroadcastReceiver.h
+++ b/library/BroadcastReceiver.h
@@ -39,7 +39,7 @@ class BroadcastReceiver
 		static const std::string DEVICE_ID_OLD;
 		static const std::string DEVICE_VERSION;
 		static const std::string STOP_MSG;
-		static const Endpoint EMPTY_ENDPOINT;
+		static Endpoint EMPTY_ENDPOINT;
 
 		/*
 		 * Construct an object for broadcast listening on the specified port
@@ -63,9 +63,16 @@ class BroadcastReceiver
 		/*
 		 * Get a reference to the endpoint at the specified index
 		 * @param index of the endpoint in the internal IpTable, should be lees than NumRemotes()
-		 * @return a reference to the endpoint at the specified index or an empty object (@see EMPTY_ENDPOINT), when the index was out of bound
+		 * @return a reference to the endpoint at the specified index or an empty object, if the index was out of bound
 		 */
 		Endpoint& GetEndpoint(size_t index);
+
+		/*
+		 * Get a reference to an endpoint with a matching fingerprint
+		 * @param fingerprint to search for
+		 * @return a reference to an endpoint with a matching fingerprint an empty object, if no matching endpoint was found
+		 */
+		Endpoint& GetEndpointByFingerprint(const uint64_t fingerprint);
 
 		/*
 		 * Listen for broadcasts until a new remote is discovered.

--- a/library/BroadcastReceiver.h
+++ b/library/BroadcastReceiver.h
@@ -48,8 +48,9 @@ class BroadcastReceiver
 		 * Construct an object for broadcast listening on the specified port
 		 * @param path to the containing files used to store recent remotes
 		 * @param port to listen on, deault is @see BROADCAST_PORT
+		 * @param onNewEndpoint callback, which is called if a new endpoint got discovered
 		 */
-		BroadcastReceiver(uint16_t port = BROADCAST_PORT, const std::string& recentFilename = "");
+		BroadcastReceiver(uint16_t port = BROADCAST_PORT, const std::string& recentFilename = "", const std::function<void(size_t index, const Endpoint& newEndpoint)>& onNewEndpoint = NULL);
 
 		/*
 		 * Stop receiving loop and cleanup
@@ -90,18 +91,11 @@ class BroadcastReceiver
 		 */
 		size_t NumRemotes(void) const;
 
-		void PrintAllEndpoints(std::ostream& out);
-
 		/**
 		 * Read recent endpoints from file and add them to mIpTable
 		 * @param filename of the file containing the recent endpoints
 		 */
 		void ReadRecentEndpoints(const std::string& filename);
-
-		/**
-		 * Callback methode to notify that a new Enpoint was add to the IpTable
-		 */
-		void SetCallbackAddedNewRemote(const std::function<void(size_t index, const Endpoint& newEndpoint)>& functionObj);
 
 		/**
 		 * Sends a stop event to terminate execution of operator()
@@ -123,7 +117,7 @@ class BroadcastReceiver
 		std::atomic<int32_t> mNumInstances;
 		std::mutex mMutex;
 		const std::string mRecentFilename;
-		std::function<void(size_t index, const Endpoint& newEndpoint)> mAddedNewRemoteCallback;
+		const std::function<void(size_t index, const Endpoint& newEndpoint)> mAddedNewRemoteCallback;
 
 		/**
 		 * Insert threadsafe a new endpoint to the mIpTable

--- a/library/BroadcastReceiver.h
+++ b/library/BroadcastReceiver.h
@@ -28,6 +28,7 @@
 #include <map>
 #include <mutex>
 #include <ostream>
+#include <set>
 #include <string>
 
 class BroadcastReceiver
@@ -101,11 +102,14 @@ class BroadcastReceiver
 
 	private:
 		const uint16_t mPort;
+		std::set<Endpoint> mIpTableShadow;
 		std::map<size_t, Endpoint> mIpTable;
 		volatile bool mIsRunning;
 		std::atomic<int32_t> mNumInstances;
 		std::mutex mMutex;
 		std::string mFavourites;
+
+		bool LockedInsert(Endpoint& e);
 };
 #endif /* #ifndef _BROADCAST_RECEIVER_H_ */
 

--- a/library/BroadcastReceiver.h
+++ b/library/BroadcastReceiver.h
@@ -59,10 +59,9 @@ class BroadcastReceiver
 
 		/**
 		 * Listen for broadcasts and print them to a stream
-		 * @param out stream to print collected remotes on
 		 * @param timeout in seconds, until execution is terminated, to wait indefinetly use NULL (default)
 		 */
-		void operator() (std::ostream& out, timeval* timeout = NULL);
+		void operator() (timeval* timeout = NULL) throw (FatalError);
 
 		/*
 		 * Get a reference to the endpoint at the specified index
@@ -117,7 +116,7 @@ class BroadcastReceiver
 		std::atomic<int32_t> mNumInstances;
 		std::mutex mMutex;
 		const std::string mRecentFilename;
-		const std::function<void(size_t index, const Endpoint& newEndpoint)> mAddedNewRemoteCallback;
+		const std::function<void(size_t index, const Endpoint& newRemote)> mOnNewRemote;
 
 		/**
 		 * Insert threadsafe a new endpoint to the mIpTable

--- a/library/BroadcastReceiver_ut.cpp
+++ b/library/BroadcastReceiver_ut.cpp
@@ -68,17 +68,9 @@ uint8_t capturedBroadcastMessage_2[110] = {
 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 //sensors
 };
 
-struct Ipv4Addr : public sockaddr_in {
-	Ipv4Addr(uint16_t port, uint32_t ip) {
-		sin_family = AF_INET;
-		sin_port = htons(port);
-		sin_addr.s_addr = htonl(ip);
-	};
-};
-
-static const Ipv4Addr g_FirstRemote(0xffff, 0x7F000001);
-static const Ipv4Addr g_SecondRemote(0xffff, 0x7F000002);
-static const Ipv4Addr g_ThirdRemote(0xffff, 0x7F000003);
+static const Ipv4Addr g_FirstRemote(0x7F000001, 0xffff);
+static const Ipv4Addr g_SecondRemote(0x7F000002, 0xffff);
+static const Ipv4Addr g_ThirdRemote(0x7F000003, 0xffff);
 
 /**************** includes, classes and functions for wrapping ****************/
 uint8_t g_TestSocketRecvBuffer[10240];
@@ -94,7 +86,7 @@ void SetTestSocket(const sockaddr_in* addr, size_t offset, void* pData, size_t d
 	g_TestSocketRecvBufferSize = offset + dataLength;
 }
 
-ClientSocket::ClientSocket(uint32_t addr, uint16_t port, int style) throw (FatalError) : mSock(0) {}
+ClientSocket::ClientSocket(uint32_t addr, uint16_t port, int style) throw (FatalError) : mSock(0), mSockAddr(addr, port) {}
 ClientSocket::~ClientSocket(void) {}
 
 UdpSocket::UdpSocket(uint32_t addr, uint16_t port, bool doBind, int enableBroadcast) throw (FatalError)

--- a/library/BroadcastReceiver_ut.cpp
+++ b/library/BroadcastReceiver_ut.cpp
@@ -220,7 +220,7 @@ int32_t ut_BroadcastReceiver_TestDifferentOrder(void)
 
 int32_t ut_BroadcastReceiver_TestRecentEndpoints(void)
 {
-	static const std::string TEST_FILENAME = "dummy2.txt";
+	static const std::string TEST_FILENAME = "TestRecentEndpoints.txt";
 	TestCaseBegin();
 	SetTestSocket(&g_FirstRemote, 0, capturedBroadcastMessage, sizeof(capturedBroadcastMessage));
 	std::ostringstream out;

--- a/library/BroadcastReceiver_ut.cpp
+++ b/library/BroadcastReceiver_ut.cpp
@@ -134,7 +134,7 @@ int32_t ut_BroadcastReceiver_TestSimple(void)
 	dummyReceiver.Stop();
 	myThread.join();
 
-	CHECK(0 == out.str().compare("0:127.0.0.1:2000  :  WiFly-EZX12345678901234567890123N\n"));
+	CHECK(0 == out.str().compare("0:0 127.0.0.1:2000  :  WiFly-EZX12345678901234567890123N\n"));
 	CHECK(1 == dummyReceiver.NumRemotes());
 	CHECK(0x7F000001 == dummyReceiver.GetEndpoint(0).GetIp());
 	CHECK(2000 == dummyReceiver.GetEndpoint(0).GetPort());
@@ -155,7 +155,7 @@ int32_t ut_BroadcastReceiver_TestTwoSame(void)
 	dummyReceiver.Stop();
 	myThread.join();
 
-	CHECK(0 == out.str().compare("0:127.0.0.1:2000  :  WiFly-EZX12345678901234567890123N\n"));
+	CHECK(0 == out.str().compare("0:0 127.0.0.1:2000  :  WiFly-EZX12345678901234567890123N\n"));
 	CHECK(1 == dummyReceiver.NumRemotes());
 	CHECK(0x7F000001 == dummyReceiver.GetEndpoint(0).GetIp());
 	CHECK(2000 == dummyReceiver.GetEndpoint(0).GetPort());
@@ -178,7 +178,7 @@ int32_t ut_BroadcastReceiver_TestNoTimeout(void)
 	dummyReceiver.Stop();
 	myThread.join();
 
-	CHECK(0 == out.str().compare("0:127.0.0.1:2000  :  WiFly-EZX12345678901234567890123N\n1:127.0.0.2:2000  :  WiFly_Light\n2:127.0.0.3:2000  :  WiFly_Light\n"));
+	CHECK(0 == out.str().compare("0:0 127.0.0.1:2000  :  WiFly-EZX12345678901234567890123N\n1:0 127.0.0.2:2000  :  WiFly_Light\n2:0 127.0.0.3:2000  :  WiFly_Light\n"));
 	CHECK(3 == dummyReceiver.NumRemotes());
 	CHECK(0x7F000001 == dummyReceiver.GetEndpoint(0).GetIp());
 	CHECK(2000 == dummyReceiver.GetEndpoint(0).GetPort());
@@ -205,9 +205,9 @@ int32_t ut_BroadcastReceiver_TestDifferentOrder(void)
 	dummyReceiver.Stop();
 	myThread.join();
 	dummyReceiver.PrintAllEndpoints(out2);
-	CHECK(0 == out.str().compare("0:127.0.0.2:2000  :  WiFly_Light\n1:127.0.0.3:2000  :  WiFly_Light\n2:127.0.0.1:2000  :  WiFly-EZX12345678901234567890123N\n"));
+	CHECK(0 == out.str().compare("0:0 127.0.0.2:2000  :  WiFly_Light\n1:0 127.0.0.3:2000  :  WiFly_Light\n2:0 127.0.0.1:2000  :  WiFly-EZX12345678901234567890123N\n"));
 	
-	CHECK(0 == out2.str().compare("0:127.0.0.1:2000  :  WiFly-EZX12345678901234567890123N\n1:127.0.0.2:2000  :  WiFly_Light\n2:127.0.0.3:2000  :  WiFly_Light\n"));
+	CHECK(0 == out2.str().compare("0:0 127.0.0.1:2000  :  WiFly-EZX12345678901234567890123N\n1:0 127.0.0.2:2000  :  WiFly_Light\n2:0 127.0.0.3:2000  :  WiFly_Light\n"));
 	CHECK(3 == dummyReceiver.NumRemotes());
 	CHECK(0x7F000001 == dummyReceiver.GetEndpoint(0).GetIp());
 	CHECK(2000 == dummyReceiver.GetEndpoint(0).GetPort());
@@ -239,11 +239,11 @@ int32_t ut_BroadcastReceiver_TestRecentEndpoints(void)
 	myThread.join();
 
 	Endpoint& firstScored = dummyReceiver.GetEndpoint(0);
-	firstScored.SetScore(100);
+	++(++firstScored);
 	Endpoint& secondScored = dummyReceiver.GetEndpoint(2);
-	secondScored.SetScore(10);
+	++(++secondScored);
 
-	dummyReceiver.WriteRecentEndpoints(TEST_FILENAME);
+	dummyReceiver.WriteRecentEndpoints(TEST_FILENAME, 2);
 	BroadcastReceiver reread;
 	reread.ReadRecentEndpoints(TEST_FILENAME);
 	

--- a/library/BroadcastReceiver_ut.cpp
+++ b/library/BroadcastReceiver_ut.cpp
@@ -135,7 +135,7 @@ int32_t ut_BroadcastReceiver_TestGetEndpoint(void)
 	g_TestOut.str("");
 	BroadcastReceiver dummyReceiver(BroadcastReceiver::BROADCAST_PORT, "", TestCallback);
 	timeval timeout = {2, 0};
-	std::thread myThread(std::ref(dummyReceiver), std::ref(g_TestOut), &timeout);
+	std::thread myThread(std::ref(dummyReceiver), &timeout);
 	nanosleep(&NANOSLEEP_TIME, NULL);
 	dummyReceiver.Stop();
 	myThread.join();
@@ -174,7 +174,7 @@ int32_t ut_BroadcastReceiver_TestSimple(void)
 	g_TestOut.str("");
 	BroadcastReceiver dummyReceiver(BroadcastReceiver::BROADCAST_PORT, "", TestCallback);
 	timeval timeout = {2, 0};
-	std::thread myThread(std::ref(dummyReceiver), std::ref(g_TestOut), &timeout);
+	std::thread myThread(std::ref(dummyReceiver), &timeout);
 	dummyReceiver.Stop();
 	myThread.join();
 
@@ -192,7 +192,7 @@ int32_t ut_BroadcastReceiver_TestTwoSame(void)
 	g_TestOut.str("");
 	BroadcastReceiver dummyReceiver(BroadcastReceiver::BROADCAST_PORT, "", TestCallback);
 	timeval timeout = {3, 0};
-	std::thread myThread(std::ref(dummyReceiver), std::ref(g_TestOut), &timeout);
+	std::thread myThread(std::ref(dummyReceiver), &timeout);
 	nanosleep(&NANOSLEEP_TIME, NULL);
 	SetTestSocket(&g_FirstRemote, 0, capturedBroadcastMessage, sizeof(capturedBroadcastMessage));
 	nanosleep(&NANOSLEEP_TIME, NULL);
@@ -212,7 +212,7 @@ int32_t ut_BroadcastReceiver_TestNoTimeout(void)
 	SetTestSocket(&g_FirstRemote, 0, capturedBroadcastMessage, sizeof(capturedBroadcastMessage));
 	g_TestOut.str("");
 	BroadcastReceiver dummyReceiver(BroadcastReceiver::BROADCAST_PORT, "", TestCallback);
-	std::thread myThread(std::ref(dummyReceiver), std::ref(std::cout));
+	std::thread myThread(std::ref(dummyReceiver));
 	nanosleep(&NANOSLEEP_TIME, NULL);
 	SetTestSocket(&g_SecondRemote, 0, capturedBroadcastMessage_2, sizeof(capturedBroadcastMessage_2));
 	nanosleep(&NANOSLEEP_TIME, NULL);
@@ -241,7 +241,7 @@ int32_t ut_BroadcastReceiver_TestRecentEndpoints(void)
 	g_TestOut.str("");
 	BroadcastReceiver dummyReceiver(BroadcastReceiver::BROADCAST_PORT, "", TestCallback);
 	timeval timeout = {2, 0};
-	std::thread myThread(std::ref(dummyReceiver), std::ref(g_TestOut), &timeout);
+	std::thread myThread(std::ref(dummyReceiver), &timeout);
 
 
 	nanosleep(&NANOSLEEP_TIME, NULL);

--- a/library/ClientSocket.cpp
+++ b/library/ClientSocket.cpp
@@ -27,10 +27,12 @@
 
 #include <stdio.h>
 
+namespace WyLight {
+
 static const int g_DebugZones = ZONE_ERROR | ZONE_WARNING | ZONE_INFO | ZONE_VERBOSE;
 
 
-WyLight::ClientSocket::ClientSocket(uint32_t addr, uint16_t port, int style) throw (FatalError) 
+ClientSocket::ClientSocket(uint32_t addr, uint16_t port, int style) throw (FatalError) 
 	: mSock(socket(AF_INET, style, 0)) 
 {
 	if( -1 == mSock) throw FatalError("Create socket failed");
@@ -41,12 +43,12 @@ WyLight::ClientSocket::ClientSocket(uint32_t addr, uint16_t port, int style) thr
 	mSockAddr.sin_addr.s_addr = htonl(addr);
 }
 
-WyLight::ClientSocket::~ClientSocket()
+ClientSocket::~ClientSocket()
 {
 	close(mSock);
 }
 
-bool WyLight::ClientSocket::Select(timeval* timeout) const throw (FatalError)
+bool ClientSocket::Select(timeval* timeout) const throw (FatalError)
 {
 	/* prepare socket set for select() */
 	fd_set readSockets;
@@ -69,7 +71,7 @@ bool WyLight::ClientSocket::Select(timeval* timeout) const throw (FatalError)
 	return false;
 }
 
-WyLight::TcpSocket::TcpSocket(uint32_t addr, uint16_t port) throw (ConnectionLost, FatalError)
+TcpSocket::TcpSocket(uint32_t addr, uint16_t port) throw (ConnectionLost, FatalError)
 	: ClientSocket(addr, port, SOCK_STREAM)
 {
 	if(0 != connect(mSock, reinterpret_cast<sockaddr*>(&mSockAddr), sizeof(mSockAddr)))
@@ -78,18 +80,18 @@ WyLight::TcpSocket::TcpSocket(uint32_t addr, uint16_t port) throw (ConnectionLos
 	}
 }
 
-size_t WyLight::TcpSocket::Recv(uint8_t* pBuffer, size_t length, timeval* timeout) const throw(FatalError)
+size_t TcpSocket::Recv(uint8_t* pBuffer, size_t length, timeval* timeout) const throw(FatalError)
 {
 	return Select(timeout) ? 0 : recv(mSock, pBuffer, length, 0);
 }
 
-size_t WyLight::TcpSocket::Send(const uint8_t* frame, size_t length) const
+size_t TcpSocket::Send(const uint8_t* frame, size_t length) const
 {
 	TraceBuffer(ZONE_INFO, frame, length, "%02x ", "Sending on socket 0x%04x, %zu bytes: ", mSock, length);
 	return send(mSock, frame, length, 0);
 }
 
-WyLight::UdpSocket::UdpSocket(uint32_t addr, uint16_t port, bool doBind, int enableBroadcast) throw (FatalError)
+UdpSocket::UdpSocket(uint32_t addr, uint16_t port, bool doBind, int enableBroadcast) throw (FatalError)
 	: ClientSocket(addr, port, SOCK_DGRAM)
 {
 	if(0 != setsockopt(mSock, SOL_SOCKET, SO_BROADCAST, &enableBroadcast, sizeof(enableBroadcast)))
@@ -103,14 +105,15 @@ WyLight::UdpSocket::UdpSocket(uint32_t addr, uint16_t port, bool doBind, int ena
 	}
 }
 
-size_t WyLight::UdpSocket::RecvFrom(uint8_t* pBuffer, size_t length, timeval* timeout, struct sockaddr* remoteAddr, socklen_t* remoteAddrLength) const throw (FatalError)
+size_t UdpSocket::RecvFrom(uint8_t* pBuffer, size_t length, timeval* timeout, struct sockaddr* remoteAddr, socklen_t* remoteAddrLength) const throw (FatalError)
 {
 	return Select(timeout) ? 0 : recvfrom(mSock, pBuffer, length, 0, remoteAddr, remoteAddrLength);
 }
 
-size_t WyLight::UdpSocket::Send(const uint8_t* frame, size_t length) const
+size_t UdpSocket::Send(const uint8_t* frame, size_t length) const
 {
 	TraceBuffer(ZONE_INFO, frame, length, "%02x ", "Sending %zu bytes: ", length);
 	return sendto(mSock, frame, length, 0, (struct sockaddr*)&mSockAddr, sizeof(mSockAddr));
 }
+} /* namespace WyLight */
 

--- a/library/ClientSocket.cpp
+++ b/library/ClientSocket.cpp
@@ -31,14 +31,9 @@ static const int g_DebugZones = ZONE_ERROR | ZONE_WARNING | ZONE_INFO | ZONE_VER
 
 
 ClientSocket::ClientSocket(uint32_t addr, uint16_t port, int style) throw (FatalError) 
-	: mSock(socket(AF_INET, style, 0)) 
+	: mSock(socket(AF_INET, style, 0)), mSockAddr(addr, port)
 {
 	if( -1 == mSock) throw FatalError("Create socket failed");
-
-	memset(&mSockAddr, 0, sizeof(mSockAddr));
-	mSockAddr.sin_family = AF_INET;
-	mSockAddr.sin_port = htons(port);
-	mSockAddr.sin_addr.s_addr = htonl(addr);
 }
 
 ClientSocket::~ClientSocket()
@@ -111,6 +106,6 @@ size_t UdpSocket::RecvFrom(uint8_t* pBuffer, size_t length, timeval* timeout, st
 size_t UdpSocket::Send(const uint8_t* frame, size_t length) const
 {
 	TraceBuffer(ZONE_INFO, frame, length, "%02x ", "Sending %zu bytes: ", length);
-	return sendto(mSock, frame, length, 0, (struct sockaddr*)&mSockAddr, sizeof(mSockAddr));
+	return sendto(mSock, frame, length, 0, reinterpret_cast<const struct sockaddr*>(&mSockAddr), sizeof(mSockAddr));
 }
 

--- a/library/ClientSocket.h
+++ b/library/ClientSocket.h
@@ -28,6 +28,19 @@
 #include <sys/socket.h>
 #include <sys/time.h>
 
+
+/**
+ * Helper class to simplify handling of sockaddr_in
+ */
+struct Ipv4Addr : public sockaddr_in {
+	Ipv4Addr(uint32_t addr, uint16_t port) {
+		memset(this, 0, sizeof(*this));
+		sin_family = AF_INET;
+		sin_port = htons(port);
+		sin_addr.s_addr = htonl(addr);
+	};
+};
+
 /**
  * Abstract base class controlling the low level socket file descriptor
  */
@@ -71,7 +84,7 @@ class ClientSocket
 		/**
 		 * IPv4 address of listening or target port
 		 */
-		struct sockaddr_in mSockAddr;
+		Ipv4Addr mSockAddr;
 };
 
 /**

--- a/library/ComProxy.cpp
+++ b/library/ComProxy.cpp
@@ -23,17 +23,19 @@
 #include "trace.h"
 #include "wifly_cmd.h"
 
+namespace WyLight {
+
 static const uint32_t g_DebugZones = ZONE_ERROR | ZONE_WARNING | ZONE_INFO | ZONE_VERBOSE;
 
 static const timeval RESPONSE_TIMEOUT = {3, 0}; // three seconds timeout for fragmented responses from pic
 
 
-WyLight::ComProxy::ComProxy(const TcpSocket& sock)
+ComProxy::ComProxy(const TcpSocket& sock)
 	: mSock(sock)
 {
 }
 
-size_t WyLight::ComProxy::Recv(uint8_t* pBuffer, const size_t length, timeval* pTimeout, bool checkCrc, bool crcInLittleEndian) const throw (ConnectionTimeout)
+size_t ComProxy::Recv(uint8_t* pBuffer, const size_t length, timeval* pTimeout, bool checkCrc, bool crcInLittleEndian) const throw (ConnectionTimeout)
 {
 	timeval endTime, now;
 	gettimeofday(&endTime, NULL);
@@ -52,19 +54,19 @@ size_t WyLight::ComProxy::Recv(uint8_t* pBuffer, const size_t length, timeval* p
 	throw ConnectionTimeout("Receive response timed out");
 }
 
-size_t WyLight::ComProxy::Send(const BlRequest& req, uint8_t* pResponse, size_t responseSize, bool doSync) const throw(ConnectionTimeout, FatalError)
+size_t ComProxy::Send(const BlRequest& req, uint8_t* pResponse, size_t responseSize, bool doSync) const throw(ConnectionTimeout, FatalError)
 {
 	Trace(ZONE_INFO, "%zu pure bytes\n", req.GetSize());
 	return Send(req.GetData(), req.GetSize(), pResponse, responseSize, req.CheckCrc(), doSync);
 }
 
-size_t WyLight::ComProxy::Send(const FwRequest& request, response_frame* pResponse, size_t responseSize) const throw(ConnectionTimeout, FatalError)
+size_t ComProxy::Send(const FwRequest& request, response_frame* pResponse, size_t responseSize) const throw(ConnectionTimeout, FatalError)
 {
 	return Send(request.GetData(), request.GetSize(), reinterpret_cast<uint8_t*>(pResponse), responseSize, true, false, false);
 }
 
 
-size_t WyLight::ComProxy::Send(const uint8_t* pRequest, const size_t requestSize, uint8_t* pResponse, size_t responseSize, bool checkCrc, bool doSync, bool crcInLittleEndian) const throw(ConnectionTimeout, FatalError)
+size_t ComProxy::Send(const uint8_t* pRequest, const size_t requestSize, uint8_t* pResponse, size_t responseSize, bool checkCrc, bool doSync, bool crcInLittleEndian) const throw(ConnectionTimeout, FatalError)
 {	
 	/* do baudrate synchronisation with bootloader if requested */
 	if(doSync)
@@ -92,7 +94,7 @@ size_t WyLight::ComProxy::Send(const uint8_t* pRequest, const size_t requestSize
 	return Recv(pResponse, responseSize, &timeout, checkCrc, crcInLittleEndian);
 }
 
-void WyLight::ComProxy::SyncWithBootloader(void) const throw (FatalError)
+void ComProxy::SyncWithBootloader(void) const throw (FatalError)
 {
 	uint8_t recvBuffer[BL_MAX_MESSAGE_LENGTH];
 	timeval timeout;
@@ -107,4 +109,4 @@ void WyLight::ComProxy::SyncWithBootloader(void) const throw (FatalError)
 		timeout = RESPONSE_TIMEOUT;
 	} while(0 == mSock.Recv(recvBuffer, sizeof(recvBuffer), &timeout));
 }
-
+} /* namespace WyLight */

--- a/library/ComProxy_ut.cpp
+++ b/library/ComProxy_ut.cpp
@@ -31,7 +31,7 @@
 #define CRC_SIZE 2
 static const uint32_t g_DebugZones = ZONE_ERROR | ZONE_WARNING | ZONE_INFO | ZONE_VERBOSE;
 
-ClientSocket::ClientSocket(uint32_t addr, uint16_t port, int style) throw (FatalError) : mSock(0) {}
+ClientSocket::ClientSocket(uint32_t addr, uint16_t port, int style) throw (FatalError) : mSock(0), mSockAddr(addr, port) {}
 ClientSocket::~ClientSocket(void) {}
 
 const BlInfo dummyBlInfo = {0xDE, 0xAD, 0xAF, 0xFE, 0xFF, 0x4, 0x0, 0xB0, 0xB1, 0xE5, 0x00};

--- a/library/Endpoint.h
+++ b/library/Endpoint.h
@@ -29,64 +29,77 @@ class Endpoint
 {
 	public:
 		Endpoint(sockaddr_storage& addr, const size_t size, uint16_t port, std::string devId = "")
+			: mScore(0)
 		{
 			assert(sizeof(sockaddr_in) == size);
-			mAddr = ntohl(((sockaddr_in&)addr).sin_addr.s_addr);
+			mIp = ntohl(((sockaddr_in&)addr).sin_addr.s_addr);
 			mPort = ntohs(port);
 			mDeviceId = devId;
 		};
 
-		Endpoint(uint32_t addr = 0, uint16_t port = 0)
-			: mAddr(addr), mPort(port), mDeviceId("")
+		Endpoint(uint32_t ip = 0, uint16_t port = 0, uint8_t score = 0)
+			: mIp(ip), mPort(port), mScore(score), mDeviceId("")
 		{
 		};
 
-		bool operator<(const Endpoint& ref) const
+		Endpoint(uint64_t value)
+			: mIp((value & 0xffffffff00000000LLU) >> 32),
+			  mPort(value & 0x00000000000000FFLLU),
+			  mScore((value & 0x0000000000FF0000LLU) >> 16),
+			  mDeviceId("")
 		{
-			return AsUint64() < ref.AsUint64();
+		};
+
+		bool operator<(const Endpoint& ref) const {
+			return (mIp < ref.GetIp())
+					|| ((mIp == ref.GetIp()) && (mPort < ref.GetPort()));
 		};
 
 		friend std::ostream& operator << (std::ostream& out, const Endpoint& ref)
 		{
-			return out << ((ref.mAddr & 0xff000000 ) >> 24) << '.'
-								 << ((ref.mAddr & 0x00ff0000 ) >> 16) << '.'
-								 << ((ref.mAddr & 0x0000ff00 ) >> 8) << '.'
-								 << (ref.mAddr & 0x000000ff )
+			return out << ((ref.mIp & 0xff000000 ) >> 24) << '.'
+								 << ((ref.mIp & 0x00ff0000 ) >> 16) << '.'
+								 << ((ref.mIp & 0x0000ff00 ) >> 8) << '.'
+								 << (ref.mIp & 0x000000ff )
 								 << ':' << ref.mPort
 								 << "  :  " << ref.mDeviceId;
 		};
 
 		/* 
-		 * @return ipv4 address(A) and port(P) as a combined 64 bit value 0xAAAAAAAA0000PPPP
+		 * @return ipv4 address(A), score(S) and port(P) as a combined 64 bit value 0xAAAAAAAA00SSPPPP
 		 */
-		uint64_t AsUint64(void) const
-		{
-			return ((uint64_t)mAddr << 32) | mPort; 
-		};
-
-		uint32_t GetIp(void) const
-		{
-			return mAddr;
-		};
-
-		uint16_t GetPort(void) const
-		{
-			return mPort;
+		uint64_t AsUint64(void) const {
+			return ((uint64_t)mIp << 32) | mScore << 16 | mPort;
 		};
 	
-		std::string GetDeviceId(void) const
-		{
+		std::string GetDeviceId(void) const {
 			return mDeviceId;
 		};
 
-		bool IsValid(void) const
-		{
-			return (0 != mAddr) && (0 != mPort);
+		uint32_t GetIp(void) const {
+			return mIp;
+		};
+
+		uint16_t GetPort(void) const {
+			return mPort;
+		};
+
+		uint8_t GetScore(void) const {
+			return mScore;
+		};
+
+		bool IsValid(void) const {
+			return (0 != mIp) && (0 != mPort);
+		};
+
+		void SetScore(uint8_t newScore) {
+			mScore = newScore;
 		};
 
 	private:
-		uint32_t mAddr;
+		uint32_t mIp;
 		uint16_t mPort;
+		uint8_t mScore;
 		std::string mDeviceId;
 };
 #endif /* #ifndef _ENDPOINT_H_ */

--- a/library/Endpoint.h
+++ b/library/Endpoint.h
@@ -18,6 +18,7 @@
 
 #ifndef _ENDPOINT_H_
 #define _ENDPOINT_H_
+#include <atomic>
 #include <cassert>
 #include <ostream>
 #include <stddef.h>
@@ -49,7 +50,8 @@ class Endpoint
 
 		friend std::ostream& operator << (std::ostream& out, const Endpoint& ref)
 		{
-			return out << ((ref.mIp & 0xff000000 ) >> 24) << '.'
+			return out << (int)ref.mScore << ' '
+								 << ((ref.mIp & 0xff000000 ) >> 24) << '.'
 								 << ((ref.mIp & 0x00ff0000 ) >> 16) << '.'
 								 << ((ref.mIp & 0x0000ff00 ) >> 8) << '.'
 								 << (ref.mIp & 0x000000ff )
@@ -80,12 +82,17 @@ class Endpoint
 			return mScore;
 		};
 
+		/*
+		 * Increment score
+		 * @return reference to itself
+		 */
+		Endpoint& operator ++(void) {
+			++mScore;
+			return *this;
+		}
+
 		bool IsValid(void) const {
 			return (0 != mIp) && (0 != mPort);
-		};
-
-		void SetScore(uint8_t newScore) {
-			mScore = newScore;
 		};
 
 	private:

--- a/library/Endpoint.h
+++ b/library/Endpoint.h
@@ -37,16 +37,8 @@ class Endpoint
 			mDeviceId = devId;
 		};
 
-		Endpoint(uint32_t ip = 0, uint16_t port = 0, uint8_t score = 0)
-			: mIp(ip), mPort(port), mScore(score), mDeviceId("")
-		{
-		};
-
-		Endpoint(uint64_t value)
-			: mIp((value & 0xffffffff00000000LLU) >> 32),
-			  mPort(value & 0x00000000000000FFLLU),
-			  mScore((value & 0x0000000000FF0000LLU) >> 16),
-			  mDeviceId("")
+		Endpoint(uint32_t ip = 0, uint16_t port = 0, uint8_t score = 0, std::string devId = "")
+			: mIp(ip), mPort(port), mScore(score), mDeviceId(devId)
 		{
 		};
 

--- a/library/Endpoint.h
+++ b/library/Endpoint.h
@@ -60,10 +60,10 @@ class Endpoint
 		};
 
 		/* 
-		 * @return ipv4 address(A), score(S) and port(P) as a combined 64 bit value 0xAAAAAAAA00SSPPPP
+		 * @return ipv4 address(A) and port(P) as a combined 64 bit value 0xAAAAAAAA0000PPPP
 		 */
 		uint64_t AsUint64(void) const {
-			return ((uint64_t)mIp << 32) | mScore << 16 | mPort;
+			return ((uint64_t)mIp << 32) | mPort;
 		};
 	
 		std::string GetDeviceId(void) const {

--- a/library/MaskBuffer.cpp
+++ b/library/MaskBuffer.cpp
@@ -19,17 +19,18 @@
 #include "MaskBuffer.h"
 #include "trace.h"
 
+namespace WyLight {
+
 static const uint32_t g_DebugZones = ZONE_ERROR | ZONE_WARNING | ZONE_INFO | ZONE_VERBOSE;
 
-
-void WyLight::BaseBuffer::AddPure(uint8_t newByte)
+void BaseBuffer::AddPure(uint8_t newByte)
 {
 	if(mLength >= mCapacity) throw FatalError("BaseBuffer overflow");
 		mData[mLength] = newByte;
 		mLength++;
 }
 
-void WyLight::MaskBuffer::Mask(const uint8_t* pInput, const uint8_t* const pInputEnd, const bool crcInLittleEndian)
+void MaskBuffer::Mask(const uint8_t* pInput, const uint8_t* const pInputEnd, const bool crcInLittleEndian)
 {
 	while(pInput < pInputEnd)
 	{
@@ -40,7 +41,7 @@ void WyLight::MaskBuffer::Mask(const uint8_t* pInput, const uint8_t* const pInpu
 	AddPure(BL_ETX);
 }
 
-void WyLight::MaskBuffer::Add(uint8_t newByte)
+void MaskBuffer::Add(uint8_t newByte)
 {
 	if(IsCtrlChar(newByte))
 	{
@@ -49,13 +50,13 @@ void WyLight::MaskBuffer::Add(uint8_t newByte)
 	AddPure(newByte);
 }
 
-void WyLight::MaskBuffer::AddWithCrc(uint8_t newByte)
+void MaskBuffer::AddWithCrc(uint8_t newByte)
 {
 	Add(newByte);
 	Crc_AddCrc16(newByte, &mCrc);
 }
 
-void WyLight::MaskBuffer::AppendCrc(bool crcInLittleEndian)
+void MaskBuffer::AppendCrc(bool crcInLittleEndian)
 {
 	if(crcInLittleEndian)
 	{
@@ -69,20 +70,20 @@ void WyLight::MaskBuffer::AppendCrc(bool crcInLittleEndian)
 	}
 }
 
-void WyLight::UnmaskBuffer::Add(uint8_t newByte)
+void UnmaskBuffer::Add(uint8_t newByte)
 {
 	AddPure(newByte);
 	AddToCrc(newByte);
 }
 
-void WyLight::UnmaskBuffer::Clear(void)
+void UnmaskBuffer::Clear(void)
 {
 	BaseBuffer::Clear();
 	mPrePreCrc = mPreCrc = 0;
 	mLastWasDLE = false;
 }
 
-void WyLight::UnmaskBuffer::CheckAndRemoveCrc(bool crcInLittleEndian) throw (FatalError)
+void UnmaskBuffer::CheckAndRemoveCrc(bool crcInLittleEndian) throw (FatalError)
 {
 	if(0x0000 == GetCrc16(crcInLittleEndian))
 	{
@@ -95,7 +96,7 @@ void WyLight::UnmaskBuffer::CheckAndRemoveCrc(bool crcInLittleEndian) throw (Fat
 	}
 }
 
-bool WyLight::UnmaskBuffer::Unmask(const uint8_t* pInput, size_t bytesMasked, bool checkCrc, bool crcInLittleEndian)
+bool UnmaskBuffer::Unmask(const uint8_t* pInput, size_t bytesMasked, bool checkCrc, bool crcInLittleEndian)
 {
 	while(bytesMasked-- > 0)
 	{
@@ -132,14 +133,14 @@ bool WyLight::UnmaskBuffer::Unmask(const uint8_t* pInput, size_t bytesMasked, bo
 	return false;
 }
 
-void WyLight::UnmaskBuffer::AddToCrc(uint8_t newByte)
+void UnmaskBuffer::AddToCrc(uint8_t newByte)
 {
 	mPrePreCrc = mPreCrc;
 	mPreCrc = mCrc;
 	Crc_AddCrc16(newByte, &mCrc);
 }
 
-uint16_t WyLight::UnmaskBuffer::GetCrc16(bool crcInLittleEndian) const
+uint16_t UnmaskBuffer::GetCrc16(bool crcInLittleEndian) const
 {
 	if(crcInLittleEndian)
 	{
@@ -150,3 +151,4 @@ uint16_t WyLight::UnmaskBuffer::GetCrc16(bool crcInLittleEndian) const
 	}
 	return mCrc;
 }
+} /* namespace WyLight */

--- a/library/TelnetProxy.cpp
+++ b/library/TelnetProxy.cpp
@@ -24,21 +24,23 @@
 #include <cctype>
 #include <sstream>
 
+namespace WyLight {
+
 static const uint32_t g_DebugZones = ZONE_ERROR | ZONE_WARNING | ZONE_INFO | ZONE_VERBOSE;
 
-WyLight::TelnetProxy::TelnetProxy(const TcpSocket& sock)
+TelnetProxy::TelnetProxy(const TcpSocket& sock)
 	: mSock(sock)
 {
 }
 
-void WyLight::TelnetProxy::ClearResponse(void) const
+void TelnetProxy::ClearResponse(void) const
 {
 	timeval timeout{0, 1};
 	uint8_t response[64];
 	while(sizeof(response) <= mSock.Recv(response, sizeof(response), &timeout));
 }
 
-bool WyLight::TelnetProxy::Close(bool doSave) const
+bool TelnetProxy::Close(bool doSave) const
 {
 	if(doSave && !Send("save\r\n", "Storing in config" PROMPT))
 	{
@@ -48,7 +50,7 @@ bool WyLight::TelnetProxy::Close(bool doSave) const
 	return Send("exit\r\n", "EXIT\r\n");
 }
 
-bool WyLight::TelnetProxy::ExtractStringOfInterest(const std::string& buffer, const std::string& searchKey, std::string& result) const
+bool TelnetProxy::ExtractStringOfInterest(const std::string& buffer, const std::string& searchKey, std::string& result) const
 {
 	Trace(ZONE_VERBOSE, buffer.c_str());
 	std::stringstream stream;
@@ -71,7 +73,7 @@ bool WyLight::TelnetProxy::ExtractStringOfInterest(const std::string& buffer, co
 	return false;
 }
 
-bool WyLight::TelnetProxy::Open(void) const
+bool TelnetProxy::Open(void) const
 {
 	static const timespec _300_TMMS = {0, 300000000};
 	static const uint8_t ENTER_CMD_MODE[] = {'$', '$', '$'}; 
@@ -96,7 +98,7 @@ bool WyLight::TelnetProxy::Open(void) const
 	return true;
 }
 
-bool WyLight::TelnetProxy::Recv(const std::string& expectedResponse) const
+bool TelnetProxy::Recv(const std::string& expectedResponse) const
 {
 	timeval timeout = {5, 0};
 	uint8_t buffer[64];
@@ -124,7 +126,7 @@ bool WyLight::TelnetProxy::Recv(const std::string& expectedResponse) const
 	return 0 == memcmp(expectedResponse.data(), buffer, expectedResponse.size());
 }
 
-bool WyLight::TelnetProxy::RecvString(const std::string& searchKey, std::string& result) const
+bool TelnetProxy::RecvString(const std::string& searchKey, std::string& result) const
 {
 	timeval timeout = {5, 0};
 	uint8_t buffer[256];
@@ -170,7 +172,7 @@ bool WyLight::TelnetProxy::RecvString(const std::string& searchKey, std::string&
 	return false;
 }
 
-void WyLight::TelnetProxy::RecvString(const std::string& getCmd, const std::string& searchKey, std::string& result) const
+void TelnetProxy::RecvString(const std::string& getCmd, const std::string& searchKey, std::string& result) const
 {
 	result.clear();
 
@@ -182,7 +184,7 @@ void WyLight::TelnetProxy::RecvString(const std::string& getCmd, const std::stri
 	RecvString(searchKey, result);
 }
 
-bool WyLight::TelnetProxy::Send(const std::string& telnetMessage, const std::string& expectedResponse) const
+bool TelnetProxy::Send(const std::string& telnetMessage, const std::string& expectedResponse) const
 {
 	if(!SendAndWaitForEcho(telnetMessage))
 	{
@@ -198,7 +200,7 @@ bool WyLight::TelnetProxy::Send(const std::string& telnetMessage, const std::str
 	return true;
 }
 
-bool WyLight::TelnetProxy::SendAndWaitForEcho(const std::string& telnetMessage) const
+bool TelnetProxy::SendAndWaitForEcho(const std::string& telnetMessage) const
 {
 	if(telnetMessage.size() != mSock.Send((uint8_t*)telnetMessage.data(), telnetMessage.size()))
 	{
@@ -208,7 +210,7 @@ bool WyLight::TelnetProxy::SendAndWaitForEcho(const std::string& telnetMessage) 
 	return Recv(telnetMessage+"\r\n");
 }
 
-bool WyLight::TelnetProxy::SendRebootCommand(void) const
+bool TelnetProxy::SendRebootCommand(void) const
 {
 	const std::string telnetMessage = "reboot\r\n";
 	if(telnetMessage.size() != mSock.Send((uint8_t*)telnetMessage.data(), telnetMessage.size()))
@@ -219,7 +221,7 @@ bool WyLight::TelnetProxy::SendRebootCommand(void) const
 	return Recv(telnetMessage);
 }
 
-bool WyLight::TelnetProxy::SendString(const std::string& command, std::string value) const
+bool TelnetProxy::SendString(const std::string& command, std::string value) const
 {
 	static const std::string REPLACE("\x21\x22\x23\x24\x25\x26\x27\x28\x29\x2A\x2B\x2C\x2D\x2E\x2F\x3A\x3B\x3C\x3D\x3E\x3F\x40\x5B\x5C\x5D\x5E\x5F\x60\x7B\x7C\x7D\x7E");
 
@@ -249,9 +251,10 @@ bool WyLight::TelnetProxy::SendString(const std::string& command, std::string va
 	return SetReplaceChar() && valueWasSet;
 }
 
-bool WyLight::TelnetProxy::SetReplaceChar(const char replace) const
+bool TelnetProxy::SetReplaceChar(const char replace) const
 {
 	std::string replaceCmd("set opt replace " + std::string(1, replace) + "\r\n");
 	return Send(replaceCmd);
 }
+} /* namespace WyLight */
 

--- a/library/TelnetProxy_ut.cpp
+++ b/library/TelnetProxy_ut.cpp
@@ -29,7 +29,7 @@
 static const uint32_t g_DebugZones = ZONE_ERROR | ZONE_WARNING | ZONE_INFO | ZONE_VERBOSE;
 static const std::string AOK_STRING(AOK);
 
-ClientSocket::ClientSocket(uint32_t addr, uint16_t port, int style) throw (FatalError) : mSock(0) {}
+ClientSocket::ClientSocket(uint32_t addr, uint16_t port, int style) throw (FatalError) : mSock(0), mSockAddr(addr, port) {}
 ClientSocket::~ClientSocket(void) {}
 
 uint8_t g_TestSocketRecvBuffer[10240];

--- a/library/WiflyControl.cpp
+++ b/library/WiflyControl.cpp
@@ -36,15 +36,17 @@ using std::cout;
 using std::ifstream;
 using std::hex;
 
+namespace WyLight {
+
 static const int g_DebugZones = ZONE_ERROR | ZONE_WARNING | ZONE_INFO | ZONE_VERBOSE;
 
-const std::string WyLight::Control
+const std::string Control
 ::LEDS_ALL{"ffffffff"};
 
-WyLight::Control::Control(uint32_t addr, uint16_t port) : mSock(addr, port), mProxy(mSock), mTelnet(mSock) {}
+Control::Control(uint32_t addr, uint16_t port) : mSock(addr, port), mProxy(mSock), mTelnet(mSock) {}
 
 /** ------------------------- BOOTLOADER METHODES ------------------------- **/
-void WyLight::Control::BlEnableAutostart(void) const throw(ConnectionTimeout, FatalError)
+void Control::BlEnableAutostart(void) const throw(ConnectionTimeout, FatalError)
 {
 	static const uint8_t value = 0xff;
 	try {
@@ -56,7 +58,7 @@ void WyLight::Control::BlEnableAutostart(void) const throw(ConnectionTimeout, Fa
 	}
 }
 
-void WyLight::Control::BlEraseEeprom(void) const throw(ConnectionTimeout, FatalError)
+void Control::BlEraseEeprom(void) const throw(ConnectionTimeout, FatalError)
 {
 	//TODO use c++11 array initialization
 	uint8_t buffer[EEPROM_SIZE];
@@ -64,7 +66,7 @@ void WyLight::Control::BlEraseEeprom(void) const throw(ConnectionTimeout, FatalE
 	BlWriteEeprom((uint32_t)0, &buffer[0], sizeof(buffer));
 }
 
-void WyLight::Control::BlEraseFlash(void) const throw(ConnectionTimeout, FatalError)
+void Control::BlEraseFlash(void) const throw(ConnectionTimeout, FatalError)
 {
 	BlInfo info;
 	BlReadInfo(info);
@@ -82,7 +84,7 @@ void WyLight::Control::BlEraseFlash(void) const throw(ConnectionTimeout, FatalEr
 	BlEraseFlashArea(FLASH_ERASE_BLOCKS * FLASH_ERASE_BLOCKSIZE -1, FLASH_ERASE_BLOCKS);
 }
 
-void WyLight::Control::BlEraseFlashArea(const uint32_t endAddress, const uint8_t numPages) const throw(ConnectionTimeout, FatalError)
+void Control::BlEraseFlashArea(const uint32_t endAddress, const uint8_t numPages) const throw(ConnectionTimeout, FatalError)
 {
 	unsigned char response;
 	BlFlashEraseRequest request(endAddress, numPages);
@@ -97,7 +99,7 @@ void WyLight::Control::BlEraseFlashArea(const uint32_t endAddress, const uint8_t
 	}
 }
 
-size_t WyLight::Control::BlRead(const BlRequest& req, unsigned char* pResponse, const size_t responseSize, bool doSync) const throw(ConnectionTimeout, FatalError)
+size_t Control::BlRead(const BlRequest& req, unsigned char* pResponse, const size_t responseSize, bool doSync) const throw(ConnectionTimeout, FatalError)
 {
 	unsigned char buffer[BL_MAX_MESSAGE_LENGTH];
 	size_t bytesReceived = mProxy.Send(req, buffer, sizeof(buffer), doSync);
@@ -111,7 +113,7 @@ size_t WyLight::Control::BlRead(const BlRequest& req, unsigned char* pResponse, 
 	return responseSize;
 }
 
-void WyLight::Control::BlReadCrcFlash(std::ostream& out, uint32_t address, size_t numBytes) const throw (ConnectionTimeout, FatalError, InvalidParameter)
+void Control::BlReadCrcFlash(std::ostream& out, uint32_t address, size_t numBytes) const throw (ConnectionTimeout, FatalError, InvalidParameter)
 {
 	out.flags ( std::ios::right | std::ios::hex | std::ios::showbase );
 	uint8_t buffer[5096];
@@ -121,7 +123,7 @@ void WyLight::Control::BlReadCrcFlash(std::ostream& out, uint32_t address, size_
 	}
 }
 
-size_t WyLight::Control::BlReadCrcFlash(unsigned char* pBuffer, unsigned int address, uint16_t numBlocks) const throw (ConnectionTimeout, FatalError, InvalidParameter)
+size_t Control::BlReadCrcFlash(unsigned char* pBuffer, unsigned int address, uint16_t numBlocks) const throw (ConnectionTimeout, FatalError, InvalidParameter)
 {
 	if(numBlocks * FLASH_ERASE_BLOCKSIZE + address > FLASH_SIZE)
 	{
@@ -146,7 +148,7 @@ size_t WyLight::Control::BlReadCrcFlash(unsigned char* pBuffer, unsigned int add
 	return sumBytesRead;
 }
 
-void WyLight::Control::BlReadEeprom(std::ostream& out, uint32_t address, size_t numBytes) const throw (ConnectionTimeout, FatalError, InvalidParameter)
+void Control::BlReadEeprom(std::ostream& out, uint32_t address, size_t numBytes) const throw (ConnectionTimeout, FatalError, InvalidParameter)
 {
 	uint8_t buffer[EEPROM_SIZE];
 	size_t bytesRead = BlReadEeprom(buffer, address, numBytes);
@@ -156,7 +158,7 @@ void WyLight::Control::BlReadEeprom(std::ostream& out, uint32_t address, size_t 
 	}
 }
 
-size_t WyLight::Control::BlReadEeprom(uint8_t* pBuffer, uint32_t address, size_t numBytes) const throw (ConnectionTimeout, FatalError, InvalidParameter)
+size_t Control::BlReadEeprom(uint8_t* pBuffer, uint32_t address, size_t numBytes) const throw (ConnectionTimeout, FatalError, InvalidParameter)
 {
 	if(numBytes + address > EEPROM_SIZE)
 	{
@@ -181,7 +183,7 @@ size_t WyLight::Control::BlReadEeprom(uint8_t* pBuffer, uint32_t address, size_t
 	return sumBytesRead;
 }
 
-void WyLight::Control::BlReadFlash(std::ostream& out, uint32_t address, size_t numBytes) const throw (ConnectionTimeout, FatalError, InvalidParameter)
+void Control::BlReadFlash(std::ostream& out, uint32_t address, size_t numBytes) const throw (ConnectionTimeout, FatalError, InvalidParameter)
 {
 	out.flags ( std::ios::right | std::ios::hex | std::ios::showbase );
 	uint8_t buffer[FLASH_SIZE];
@@ -191,7 +193,7 @@ void WyLight::Control::BlReadFlash(std::ostream& out, uint32_t address, size_t n
 	}
 }
 
-size_t WyLight::Control::BlReadFlash(uint8_t* pBuffer, uint32_t address, size_t numBytes) const throw (ConnectionTimeout, FatalError, InvalidParameter)
+size_t Control::BlReadFlash(uint8_t* pBuffer, uint32_t address, size_t numBytes) const throw (ConnectionTimeout, FatalError, InvalidParameter)
 {
 	if(numBytes + address > FLASH_SIZE)
 	{
@@ -217,7 +219,7 @@ size_t WyLight::Control::BlReadFlash(uint8_t* pBuffer, uint32_t address, size_t 
 	return sumBytesRead;
 }
 
-std::string WyLight::Control::BlReadFwVersion(void) const throw (ConnectionTimeout, FatalError)
+std::string Control::BlReadFwVersion(void) const throw (ConnectionTimeout, FatalError)
 {
 	BlInfo info;
 	BlReadInfo(info);
@@ -261,13 +263,13 @@ std::string WyLight::Control::BlReadFwVersion(void) const throw (ConnectionTimeo
 	return std::string((const char*)pString - 8, 7);
 }
 
-void WyLight::Control::BlReadInfo(BlInfo& blInfo) const throw (ConnectionTimeout, FatalError)
+void Control::BlReadInfo(BlInfo& blInfo) const throw (ConnectionTimeout, FatalError)
 {
 	BlInfoRequest request;
 	BlRead(request, reinterpret_cast<unsigned char*>(&blInfo), sizeof(BlInfo));
 }
 
-void WyLight::Control::BlWriteFlash(unsigned int address, unsigned char* pBuffer, size_t bufferLength) const throw (ConnectionTimeout, FatalError, InvalidParameter)
+void Control::BlWriteFlash(unsigned int address, unsigned char* pBuffer, size_t bufferLength) const throw (ConnectionTimeout, FatalError, InvalidParameter)
 {
 	if(bufferLength + address > FLASH_SIZE)
 	{
@@ -301,7 +303,7 @@ void WyLight::Control::BlWriteFlash(unsigned int address, unsigned char* pBuffer
 	}
 }
 
-void WyLight::Control::BlWriteEeprom(unsigned int address, const uint8_t* pBuffer, size_t bufferLength) const throw (ConnectionTimeout, FatalError, InvalidParameter)
+void Control::BlWriteEeprom(unsigned int address, const uint8_t* pBuffer, size_t bufferLength) const throw (ConnectionTimeout, FatalError, InvalidParameter)
 {
 	if(bufferLength + address > EEPROM_SIZE)
 	{
@@ -336,7 +338,7 @@ void WyLight::Control::BlWriteEeprom(unsigned int address, const uint8_t* pBuffe
 	}
 }
 
-void WyLight::Control::BlProgramFlash(const std::string& pFilename) const throw (ConnectionTimeout, FatalError)
+void Control::BlProgramFlash(const std::string& pFilename) const throw (ConnectionTimeout, FatalError)
 {
 	std::ifstream hexFile;
 	hexFile.open(const_cast<char*>(pFilename.c_str()), ifstream::in);
@@ -438,7 +440,7 @@ void WyLight::Control::BlProgramFlash(const std::string& pFilename) const throw 
 	BlWriteFlash(info.GetAddress() - FLASH_WRITE_BLOCKSIZE, &appVecBuf[0], FLASH_WRITE_BLOCKSIZE);
 }
 
-void WyLight::Control::BlRunApp(void) const throw (ConnectionTimeout, FatalError)
+void Control::BlRunApp(void) const throw (ConnectionTimeout, FatalError)
 {
 	BlRunAppRequest request;
 	unsigned char buffer[32];
@@ -454,7 +456,7 @@ void WyLight::Control::BlRunApp(void) const throw (ConnectionTimeout, FatalError
 	throw FatalError(std::string(__FILE__) + ':' + __FUNCTION__ + ": response of wrong length");
 }
 
-std::string WyLight::Control::ConfGetSsid(void) const
+std::string Control::ConfGetSsid(void) const
 {
 	std::string result{};
 	if(mTelnet.Open())
@@ -465,7 +467,7 @@ std::string WyLight::Control::ConfGetSsid(void) const
 	return result;
 }
 
-bool WyLight::Control::ConfModuleAsSoftAP(const std::string& accesspointName) const
+bool Control::ConfModuleAsSoftAP(const std::string& accesspointName) const
 {
 	if(!ConfSetDeviceId(accesspointName))
 	{
@@ -533,7 +535,7 @@ bool WyLight::Control::ConfModuleAsSoftAP(const std::string& accesspointName) co
 	return ConfRebootWlanModule();
 }
 
-bool WyLight::Control::ConfModuleForWlan(const std::string& phrase, const std::string& ssid, const std::string& deviceId) const
+bool Control::ConfModuleForWlan(const std::string& phrase, const std::string& ssid, const std::string& deviceId) const
 {
 	if(!ConfSetDefaults())
 	{
@@ -556,7 +558,7 @@ bool WyLight::Control::ConfModuleForWlan(const std::string& phrase, const std::s
 	return ConfRebootWlanModule();
 }
 
-bool WyLight::Control::ConfSetDefaults(void) const
+bool Control::ConfSetDefaults(void) const
 {
 	static const std::string commands[] = {
 		"set broadcast interval 1\r\n",    // to support fast broadcast recognition
@@ -596,7 +598,7 @@ bool WyLight::Control::ConfSetDefaults(void) const
 	return mTelnet.Close(true);
 }
 
-bool WyLight::Control::ConfSetWlan(const std::string& phrase, const std::string& ssid) const
+bool Control::ConfSetWlan(const std::string& phrase, const std::string& ssid) const
 {
 	static const size_t PHRASE_MAX = 63;
 	static const size_t SSID_MAX = 32;
@@ -635,7 +637,7 @@ bool WyLight::Control::ConfSetWlan(const std::string& phrase, const std::string&
 	return mTelnet.Close(true);
 }
 
-bool WyLight::Control::ConfSetDeviceId(const std::string& name) const
+bool Control::ConfSetDeviceId(const std::string& name) const
 {
 	static const size_t NAME_MAX_LEN = 32;
 	
@@ -661,7 +663,7 @@ bool WyLight::Control::ConfSetDeviceId(const std::string& name) const
 	return mTelnet.Close(true);
 }
 
-bool WyLight::Control::ConfRebootWlanModule(void) const
+bool Control::ConfRebootWlanModule(void) const
 {
 	if(!mTelnet.Open())
 	{
@@ -680,53 +682,53 @@ bool WyLight::Control::ConfRebootWlanModule(void) const
 	return true;
 }
 
-void WyLight::Control::FwClearScript(void) throw (ConnectionTimeout, FatalError, ScriptBufferFull)
+void Control::FwClearScript(void) throw (ConnectionTimeout, FatalError, ScriptBufferFull)
 {
 	SimpleResponse response(CLEAR_SCRIPT);
 	FwSend(FwReqClearScript(), response);
 }
 
-std::string WyLight::Control::FwGetCycletime(void) throw (ConnectionTimeout, FatalError, ScriptBufferFull)
+std::string Control::FwGetCycletime(void) throw (ConnectionTimeout, FatalError, ScriptBufferFull)
 {
 	CycletimeResponse response;
 	FwSend(FwReqGetCycletime(), response);
 	return response.ToString();
 }
 
-void WyLight::Control::FwGetRtc(tm& timeValue) throw (ConnectionTimeout, FatalError, ScriptBufferFull)
+void Control::FwGetRtc(tm& timeValue) throw (ConnectionTimeout, FatalError, ScriptBufferFull)
 {
 	RtcResponse response;
 	FwSend(FwReqGetRtc(), response);
 	timeValue = response.GetRealTime();
 }
 
-std::string WyLight::Control::FwGetTracebuffer(void) throw (ConnectionTimeout, FatalError, ScriptBufferFull)
+std::string Control::FwGetTracebuffer(void) throw (ConnectionTimeout, FatalError, ScriptBufferFull)
 {
 	TracebufferResponse response;
 	FwSend(FwReqGetTracebuffer(), response);
 	return response.ToString();
 }
 
-std::string WyLight::Control::FwGetVersion(void) throw (ConnectionTimeout, FatalError, ScriptBufferFull)
+std::string Control::FwGetVersion(void) throw (ConnectionTimeout, FatalError, ScriptBufferFull)
 {
 	FirmwareVersionResponse response;
 	FwSend(FwReqGetVersion(), response);
 	return response.ToString();
 }
 
-void WyLight::Control::FwLoopOff(uint8_t numLoops) throw (ConnectionTimeout, FatalError, ScriptBufferFull)
+void Control::FwLoopOff(uint8_t numLoops) throw (ConnectionTimeout, FatalError, ScriptBufferFull)
 {
 	SimpleResponse response(LOOP_OFF);
 	FwSend(FwReqLoopOff(numLoops), response);
 }
 
-void WyLight::Control::FwLoopOn(void) throw (ConnectionTimeout, FatalError, ScriptBufferFull)
+void Control::FwLoopOn(void) throw (ConnectionTimeout, FatalError, ScriptBufferFull)
 {
 	SimpleResponse response(LOOP_ON);
 	FwSend(FwReqLoopOn(), response);
 }
 
-WyLight::FwResponse& WyLight::Control::FwSend(const FwRequest& request, FwResponse& response) const throw (ConnectionTimeout, FatalError, ScriptBufferFull)
+FwResponse& Control::FwSend(const FwRequest& request, FwResponse& response) const throw (ConnectionTimeout, FatalError, ScriptBufferFull)
 {
 	response_frame buffer;
 	size_t numCrcRetries = 5;
@@ -743,48 +745,48 @@ WyLight::FwResponse& WyLight::Control::FwSend(const FwRequest& request, FwRespon
 	throw FatalError(std::string(__FILE__) + ':' + __FUNCTION__ + ": Too many retries");
 }
 
-void WyLight::Control::FwSetColorDirect(const uint8_t* pBuffer, size_t bufferLength) throw (ConnectionTimeout, FatalError, ScriptBufferFull)
+void Control::FwSetColorDirect(const uint8_t* pBuffer, size_t bufferLength) throw (ConnectionTimeout, FatalError, ScriptBufferFull)
 {
 	SimpleResponse response(SET_COLOR_DIRECT);  
 	FwSend(FwReqSetColorDirect(pBuffer, bufferLength), response);
 }
 
-void WyLight::Control::FwSetFade(uint32_t argb, uint16_t fadeTime, uint32_t addr, bool parallelFade) throw (ConnectionTimeout, FatalError, ScriptBufferFull)
+void Control::FwSetFade(uint32_t argb, uint16_t fadeTime, uint32_t addr, bool parallelFade) throw (ConnectionTimeout, FatalError, ScriptBufferFull)
 {
 	SimpleResponse response(SET_FADE);
 	FwSend(FwReqSetFade(argb, fadeTime, addr, parallelFade), response);
 }
 
-void WyLight::Control::FwSetFade(const string& rgb, uint16_t fadeTime, const string& addr, bool parallelFade) throw (ConnectionTimeout, FatalError, ScriptBufferFull)
+void Control::FwSetFade(const string& rgb, uint16_t fadeTime, const string& addr, bool parallelFade) throw (ConnectionTimeout, FatalError, ScriptBufferFull)
 {
 	FwSetFade(0xff000000 | WiflyColor::ToARGB(rgb), fadeTime, WiflyColor::ToARGB(addr), parallelFade);
 }
 
-void WyLight::Control::FwSetGradient(uint32_t argb_1, uint32_t argb_2, uint16_t fadeTime, bool parallelFade, uint8_t length, uint8_t offset)
+void Control::FwSetGradient(uint32_t argb_1, uint32_t argb_2, uint16_t fadeTime, bool parallelFade, uint8_t length, uint8_t offset)
 {
 	SimpleResponse response(SET_GRADIENT);
 	FwSend(FwReqSetGradient(argb_1, argb_2, fadeTime, parallelFade, length, offset), response);
 }
 
 
-void WyLight::Control::FwSetGradient(const string& rgb_1, const string& rgb_2, uint16_t fadeTime, bool parallelFade, uint8_t length, uint8_t offset)
+void Control::FwSetGradient(const string& rgb_1, const string& rgb_2, uint16_t fadeTime, bool parallelFade, uint8_t length, uint8_t offset)
 {
 	FwSetGradient(0xff000000 | WiflyColor::ToARGB(rgb_1), 0xff000000 | WiflyColor::ToARGB(rgb_2), fadeTime, parallelFade, length, offset);
 }
 
-void WyLight::Control::FwSetRtc(const tm& timeValue) throw (ConnectionTimeout, FatalError, ScriptBufferFull)
+void Control::FwSetRtc(const tm& timeValue) throw (ConnectionTimeout, FatalError, ScriptBufferFull)
 {
 	SimpleResponse response(SET_RTC);
 	FwSend(FwReqSetRtc(timeValue), response);
 }
 
-void WyLight::Control::FwSetWait(uint16_t waitTime) throw (ConnectionTimeout, FatalError, ScriptBufferFull)
+void Control::FwSetWait(uint16_t waitTime) throw (ConnectionTimeout, FatalError, ScriptBufferFull)
 {
 	SimpleResponse response(WAIT);
 	FwSend(FwReqWait(waitTime), response);
 }
 
-void WyLight::Control::FwStressTest(void)
+void Control::FwStressTest(void)
 {	
 	FwClearScript();
 
@@ -797,7 +799,7 @@ void WyLight::Control::FwStressTest(void)
 	}
 }
 
-std::string WyLight::Control::ExtractFwVersion(const std::string& pFilename) const
+std::string Control::ExtractFwVersion(const std::string& pFilename) const
 {
 	std::ifstream hexFile;
 	hexFile.open(const_cast<char*>(pFilename.c_str()), ifstream::in);
@@ -825,7 +827,7 @@ std::string WyLight::Control::ExtractFwVersion(const std::string& pFilename) con
 	return std::string((const char*)&buffer[0], 7);
 }
 
-WyLight::Control& WyLight::Control::operator<<(const FwCommand& cmd)
+Control& Control::operator<<(const FwCommand& cmd)
 {
 	this->FwSend(*cmd.GetRequest(), *cmd.GetResponse());
 	return *this;
@@ -833,7 +835,7 @@ WyLight::Control& WyLight::Control::operator<<(const FwCommand& cmd)
 
 
 
-void WyLight::Control::FwTest(void)
+void Control::FwTest(void)
 {
 #if 1
 	static const timespec sleepTime{0, 50000000};
@@ -881,9 +883,9 @@ void WyLight::Control::FwTest(void)
 #endif
 }
 
-void WyLight::Control::FwStartBl(void) throw (ConnectionTimeout, FatalError, ScriptBufferFull)
+void Control::FwStartBl(void) throw (ConnectionTimeout, FatalError, ScriptBufferFull)
 {
 	SimpleResponse response(START_BL);
 	FwSend(FwReqStartBl(), response);
 }
-
+} /* namespace WyLight */

--- a/library/WiflyControl.cpp
+++ b/library/WiflyControl.cpp
@@ -454,8 +454,6 @@ void WyLight::Control::BlRunApp(void) const throw (ConnectionTimeout, FatalError
 	throw FatalError(std::string(__FILE__) + ':' + __FUNCTION__ + ": response of wrong length");
 }
 
-#pragma mark RN171-METHODES
-
 std::string WyLight::Control::ConfGetSsid(void) const
 {
 	std::string result{};
@@ -535,7 +533,7 @@ bool WyLight::Control::ConfModuleAsSoftAP(const std::string& accesspointName) co
 	return ConfRebootWlanModule();
 }
 
-bool WyLight::Control::ConfModuleForWlan(const std::string& phrase, const std::string& ssid, const std::string& name) const
+bool WyLight::Control::ConfModuleForWlan(const std::string& phrase, const std::string& ssid, const std::string& deviceId) const
 {
 	if(!ConfSetDefaults())
 	{
@@ -549,7 +547,7 @@ bool WyLight::Control::ConfModuleForWlan(const std::string& phrase, const std::s
 		return false;
 	}
 	
-	if(!ConfSetDeviceId(name))
+	if(!ConfSetDeviceId(deviceId))
 	{
 		Trace(ZONE_ERROR, "set device name failed\n");
 		return false;
@@ -681,8 +679,6 @@ bool WyLight::Control::ConfRebootWlanModule(void) const
 	}
 	return true;
 }
-
-#pragma mark FIRMWARE-METHODES
 
 void WyLight::Control::FwClearScript(void) throw (ConnectionTimeout, FatalError, ScriptBufferFull)
 {

--- a/library/WiflyControl.h
+++ b/library/WiflyControl.h
@@ -510,27 +510,11 @@ class Control
 		 */
 		bool ConfSetWlan(const std::string& phrase, const std::string& ssid) const;
 	
-
 /* ------------------ friendships for unittesting only ------------------- */
-	   /**
-		* friendships for unittesting only
-		*/
-		friend bool ut_WiflyControl_ConfSetDefaults(Control& ref);
-	
-		/**
-		 * friendships for unittesting only
-		 */
-		friend bool ut_WiflyControl_ConfSetWlan(Control& ref, const std::string& phrase, const std::string& ssid);
-	
-		/**
-		 * friendships for unittesting only
-		 */
 		friend size_t ut_WiflyControl_BlEepromWrite(void);
-
-		/**
-		* friendships for unittesting only
-		*/
 		friend size_t ut_WiflyControl_BlFlashWrite(void);
+		friend size_t ut_WiflyControl_ConfSetDefaults(void);
+		friend size_t ut_WiflyControl_ConfSetWlan(void);
 };
 }
 #endif /* #ifndef _WIFLYCONTROL_H_ */

--- a/library/WiflyControl.h
+++ b/library/WiflyControl.h
@@ -190,7 +190,7 @@ class Control
 		 * @param name 1 - 32 characters, unique name which apperas in the broadcast message
 		 * @return false, in case of an error
 		 */
-		bool ConfModuleForWlan(const std::string& phrase, const std::string& ssid, const std::string& name = "Wifly_Light") const;
+		bool ConfModuleForWlan(const std::string& phrase, const std::string& ssid, const std::string& deviceId = "Wifly_Light") const;
 
 		/**
 		 * Reboot the modul. ATTENTION: You have to reconnect after a reboot

--- a/library/WiflyControlException.h
+++ b/library/WiflyControlException.h
@@ -28,6 +28,21 @@
 #include "wifly_cmd.h"
 #include "BlRequest.h"
 
+
+#if defined(__cplusplus) && (__cplusplus < 201103L)
+#warning "Check for a newer compiler to avoid using this C++11 wrapper file"
+#include <sstream>
+namespace std {
+template <class T>
+std::string to_string(T value)
+{
+	std::stringstream converter;
+	converter << value;
+	return converter.str();
+};
+}
+#endif
+
 namespace WyLight{
 
 /******************************************************************************/

--- a/library/WiflyControlNoThrow.cpp
+++ b/library/WiflyControlNoThrow.cpp
@@ -18,153 +18,155 @@
 
 #include "WiflyControlNoThrow.h"
 
+namespace WyLight {
+
 static const int g_DebugZones = ZONE_ERROR | ZONE_WARNING | ZONE_INFO | ZONE_VERBOSE;
 
-WyLight::ControlNoThrow::ControlNoThrow(uint32_t addr, uint16_t port)
+ControlNoThrow::ControlNoThrow(uint32_t addr, uint16_t port)
 : mControl(addr, port) {}
 
-uint32_t WyLight::ControlNoThrow::BlEnableAutostart(void) const
+uint32_t ControlNoThrow::BlEnableAutostart(void) const
 {
 	return Try(std::bind(&Control::BlEnableAutostart, std::ref(mControl)));
 }
 
-uint32_t WyLight::ControlNoThrow::BlEraseEeprom(void) const
+uint32_t ControlNoThrow::BlEraseEeprom(void) const
 {
 	return Try(std::bind(&Control::BlEraseEeprom, std::ref(mControl)));
 }
 
-uint32_t WyLight::ControlNoThrow::BlEraseFlash(void) const
+uint32_t ControlNoThrow::BlEraseFlash(void) const
 {
 	return Try(std::bind(&Control::BlEraseFlash, std::ref(mControl)));
 }
 
-uint32_t WyLight::ControlNoThrow::BlReadCrcFlash(std::ostream& out, uint32_t address, size_t numBlocks) const
+uint32_t ControlNoThrow::BlReadCrcFlash(std::ostream& out, uint32_t address, size_t numBlocks) const
 {
 	return Try(std::bind(static_cast<void(Control::*)(std::ostream&, uint32_t, size_t)const>(&Control::BlReadCrcFlash), std::ref(mControl), std::ref(out), address, numBlocks));
 }
 
-uint32_t WyLight::ControlNoThrow::BlReadEeprom(std::ostream& out, uint32_t address, size_t numBytes) const
+uint32_t ControlNoThrow::BlReadEeprom(std::ostream& out, uint32_t address, size_t numBytes) const
 {
 	return Try(std::bind(static_cast<void(Control::*)(std::ostream&, uint32_t, size_t)const>(&Control::BlReadEeprom), std::ref(mControl), std::ref(out), address, numBytes));
 }
 
-uint32_t WyLight::ControlNoThrow::BlReadFlash(std::ostream& out, uint32_t address, size_t numBytes) const
+uint32_t ControlNoThrow::BlReadFlash(std::ostream& out, uint32_t address, size_t numBytes) const
 {
 	return Try(std::bind(static_cast<void(Control::*)(std::ostream&, uint32_t, size_t)const>(&Control::BlReadFlash), std::ref(mControl), std::ref(out), address, numBytes));
 }
 
-uint32_t WyLight::ControlNoThrow::BlReadFwVersion(std::string& versionString) const
+uint32_t ControlNoThrow::BlReadFwVersion(std::string& versionString) const
 {
 	return Try(std::bind(&Control::BlReadFwVersion, std::ref(mControl)), versionString);
 }
 
-uint32_t WyLight::ControlNoThrow::BlReadInfo(BlInfo& blInfo) const
+uint32_t ControlNoThrow::BlReadInfo(BlInfo& blInfo) const
 {
 	return Try(std::bind(&Control::BlReadInfo, std::ref(mControl), std::ref(blInfo)));
 }
 
-uint32_t WyLight::ControlNoThrow::BlProgramFlash(const std::string& filename) const
+uint32_t ControlNoThrow::BlProgramFlash(const std::string& filename) const
 {
 	return Try(std::bind(&Control::BlProgramFlash, std::ref(mControl), filename));
 }
 
-uint32_t WyLight::ControlNoThrow::BlRunApp(void) const
+uint32_t ControlNoThrow::BlRunApp(void) const
 {
 	return Try(std::bind(&Control::BlRunApp, std::ref(mControl)));
 }
 
-uint32_t WyLight::ControlNoThrow::ConfGetSsid(std::string& ssid) const
+uint32_t ControlNoThrow::ConfGetSsid(std::string& ssid) const
 {
 	ssid = mControl.ConfGetSsid();
 	return NO_ERROR;
 }
 
-uint32_t WyLight::ControlNoThrow::ConfModuleForWlan(const std::string &phrase, const std::string &ssid, const std::string &name) const
+uint32_t ControlNoThrow::ConfModuleForWlan(const std::string &phrase, const std::string &ssid, const std::string &name) const
 {
 	return mControl.ConfModuleForWlan(phrase, ssid, name) ? NO_ERROR : FATAL_ERROR;
 }
 
-uint32_t WyLight::ControlNoThrow::ConfModuleAsSoftAP(const std::string &name) const
+uint32_t ControlNoThrow::ConfModuleAsSoftAP(const std::string &name) const
 {
 	return mControl.ConfModuleAsSoftAP(name) ? NO_ERROR : FATAL_ERROR;
 }
 
-uint32_t WyLight::ControlNoThrow::ConfRebootWlanModule(void) const
+uint32_t ControlNoThrow::ConfRebootWlanModule(void) const
 {
 	return mControl.ConfRebootWlanModule() ? NO_ERROR : FATAL_ERROR;
 }
 
-uint32_t WyLight::ControlNoThrow::ConfSetDeviceId(const std::string &name) const
+uint32_t ControlNoThrow::ConfSetDeviceId(const std::string &name) const
 {
 	return mControl.ConfSetDeviceId(name) ? NO_ERROR : FATAL_ERROR;
 }
 
-uint32_t WyLight::ControlNoThrow::FwClearScript(void)
+uint32_t ControlNoThrow::FwClearScript(void)
 {
 	return Try(std::bind(&Control::FwClearScript, std::ref(mControl)));
 }
 
-uint32_t WyLight::ControlNoThrow::FwGetCycletime(std::string& output)
+uint32_t ControlNoThrow::FwGetCycletime(std::string& output)
 {
 	return Try(std::bind(&Control::FwGetCycletime, std::ref(mControl)), output);
 }
 
-uint32_t WyLight::ControlNoThrow::FwGetRtc(tm& timeValue)
+uint32_t ControlNoThrow::FwGetRtc(tm& timeValue)
 {
 	return Try(std::bind(&Control::FwGetRtc, std::ref(mControl), std::ref(timeValue)));
 }
 
-uint32_t WyLight::ControlNoThrow::FwGetTracebuffer(std::string& output)
+uint32_t ControlNoThrow::FwGetTracebuffer(std::string& output)
 {
 	return Try(std::bind(&Control::FwGetTracebuffer, std::ref(mControl)), output);
 }
 
-uint32_t WyLight::ControlNoThrow::FwGetVersion(std::string& output)
+uint32_t ControlNoThrow::FwGetVersion(std::string& output)
 {
 	return Try(std::bind(&Control::FwGetVersion, std::ref(mControl)), output);
 }
 
-uint32_t WyLight::ControlNoThrow::FwLoopOff(const uint8_t numLoops)
+uint32_t ControlNoThrow::FwLoopOff(const uint8_t numLoops)
 {
 	return Try(std::bind(&Control::FwLoopOff, std::ref(mControl), numLoops));
 }
 
-uint32_t WyLight::ControlNoThrow::FwLoopOn(void)
+uint32_t ControlNoThrow::FwLoopOn(void)
 {
 	return Try(std::bind(&Control::FwLoopOn, std::ref(mControl)));
 }
 
-uint32_t WyLight::ControlNoThrow::FwSetColorDirect(const uint8_t* pBuffer, const size_t bufferLength)
+uint32_t ControlNoThrow::FwSetColorDirect(const uint8_t* pBuffer, const size_t bufferLength)
 {
 	return Try(std::bind(&Control::FwSetColorDirect, std::ref(mControl), pBuffer, bufferLength));
 }
 
-uint32_t WyLight::ControlNoThrow::FwSetFade(const uint32_t argb, const uint16_t fadeTime, const uint32_t addr, const bool parallelFade)
+uint32_t ControlNoThrow::FwSetFade(const uint32_t argb, const uint16_t fadeTime, const uint32_t addr, const bool parallelFade)
 {
 	return Try(std::bind(static_cast<void(Control::*)(uint32_t, uint16_t, uint32_t, bool)>(&Control::FwSetFade), std::ref(mControl), argb, fadeTime, addr, parallelFade));
 }
 
-uint32_t WyLight::ControlNoThrow::FwSetGradient(const uint32_t argb_1, const uint32_t argb_2, const uint16_t fadeTime, const bool parallelFade, const uint8_t length, uint8_t offset)
+uint32_t ControlNoThrow::FwSetGradient(const uint32_t argb_1, const uint32_t argb_2, const uint16_t fadeTime, const bool parallelFade, const uint8_t length, uint8_t offset)
 {
 	return Try(std::bind(static_cast<void(Control::*)(uint32_t, uint32_t, uint16_t, bool, uint8_t, uint8_t)>(&Control::FwSetGradient), std::ref(mControl), argb_1, argb_2, fadeTime, parallelFade, length, offset));
 }
 
-uint32_t WyLight::ControlNoThrow::FwSetRtc(const tm& timeValue)
+uint32_t ControlNoThrow::FwSetRtc(const tm& timeValue)
 {
 	return Try(std::bind(&Control::FwSetRtc, std::ref(mControl), timeValue));
 }
 
-uint32_t WyLight::ControlNoThrow::FwSetWait(const uint16_t waitTime)
+uint32_t ControlNoThrow::FwSetWait(const uint16_t waitTime)
 {
 	return Try(std::bind(&Control::FwSetWait, std::ref(mControl), waitTime));
 }
 
-uint32_t WyLight::ControlNoThrow::FwStartBl(void)
+uint32_t ControlNoThrow::FwStartBl(void)
 {
 	return Try(std::bind(&Control::FwStartBl, std::ref(mControl)));
 }
 
-uint32_t WyLight::ControlNoThrow::Try(const std::function<std::string(void)> call, std::string& returnString) const
+uint32_t ControlNoThrow::Try(const std::function<std::string(void)> call, std::string& returnString) const
 {
 	try {
 		returnString = call();
@@ -180,7 +182,7 @@ uint32_t WyLight::ControlNoThrow::Try(const std::function<std::string(void)> cal
 }
 
 
-uint32_t WyLight::ControlNoThrow::Try(const std::function<void(void)> call) const
+uint32_t ControlNoThrow::Try(const std::function<void(void)> call) const
 {
 	try {
 		call();
@@ -194,4 +196,5 @@ uint32_t WyLight::ControlNoThrow::Try(const std::function<void(void)> call) cons
 		return FATAL_ERROR;
 	}
 }
+} /* namespace WyLight */
 

--- a/library/WiflyControlNoThrow_ut.cpp
+++ b/library/WiflyControlNoThrow_ut.cpp
@@ -25,7 +25,7 @@
 static const uint32_t g_DebugZones = ZONE_ERROR | ZONE_WARNING | ZONE_INFO | ZONE_VERBOSE;
 
 /***** Wrappers ****/
-ClientSocket::ClientSocket(uint32_t, uint16_t, int) throw (FatalError) : mSock(0) {}
+ClientSocket::ClientSocket(uint32_t addr, uint16_t port, int style) throw (FatalError) : mSock(0), mSockAddr(addr, port) {}
 ClientSocket::~ClientSocket(void) {}
 TcpSocket::TcpSocket(uint32_t addr, uint16_t port) throw (ConnectionLost, FatalError) : ClientSocket(addr, port, 0) {}
 size_t TcpSocket::Recv(uint8_t* pBuffer, size_t length, timeval* timeout) const throw (FatalError) { return 0;}

--- a/library/WiflyControl_ut.cpp
+++ b/library/WiflyControl_ut.cpp
@@ -25,7 +25,7 @@
 #include "intelhexclass.h"
 #include "FwRequest.h"
 
-using namespace WyLight;
+namespace WyLight {
 
 static const uint32_t g_DebugZones = ZONE_ERROR | ZONE_WARNING | ZONE_INFO | ZONE_VERBOSE;
 
@@ -141,25 +141,7 @@ size_t ComProxy::Send(const FwRequest& request, response_frame* pResponse, size_
 	return pResponse->length;
 }
 
-namespace WyLight {
-/**
- * friendships for unittesting only
- */
-bool ut_WiflyControl_ConfSetDefaults(WyLight::Control& ref)
-{
-	return ref.ConfSetDefaults();
-}
-
-/**
- * friendships for unittesting only
- */
-bool ut_WiflyControl_ConfSetWlan(WyLight::Control& ref, const std::string& phrase, const std::string& ssid)
-{
-	return ref.ConfSetWlan(phrase, ssid);
-}
-}
-
-// wrapper to test WyLight::Control
+// wrapper to test Control
 static std::list<std::string> g_TestBuffer;
 static bool g_ProxySaved = false;
 static bool g_ProxyConnected = false;
@@ -215,7 +197,7 @@ size_t ut_WiflyControl_BlEraseEeprom(void)
 		g_EepromRndDataPool[i] = (uint8_t) rand() % 255;
 	}
 	
-	WyLight::Control testctrl(0,0);
+	Control testctrl(0,0);
 	
 	testctrl.BlEraseEeprom();
 	
@@ -236,7 +218,7 @@ size_t ut_WiflyControl_BlEepromRead(void)
 	for(unsigned int i = 0; i < sizeof(g_EepromRndDataPool); i++)
 		g_EepromRndDataPool[i] = (uint8_t) rand() % 255;
 	
-	WyLight::Control testctrl(0,0);
+	Control testctrl(0,0);
 	
 	std::stringstream mStream;
 	
@@ -257,7 +239,6 @@ size_t ut_WiflyControl_BlEepromRead(void)
 	
 }
 
-namespace WyLight {
 size_t ut_WiflyControl_BlEepromWrite(void)
 {
 	TestCaseBegin();
@@ -273,7 +254,7 @@ size_t ut_WiflyControl_BlEepromWrite(void)
 		m_EepromRndDataPool[i] = (uint8_t) rand() % 255;
 	}
 	
-	WyLight::Control testctrl(0,0);
+	Control testctrl(0,0);
 	
 	testctrl.BlWriteEeprom(0, m_EepromRndDataPool, EEPROM_SIZE);
 		
@@ -283,8 +264,6 @@ size_t ut_WiflyControl_BlEepromWrite(void)
 	}
 	
 	TestCaseEnd();
-
-}
 }
 
 size_t ut_WiflyControl_BlEraseFlash(void)
@@ -298,7 +277,7 @@ size_t ut_WiflyControl_BlEraseFlash(void)
 		g_FlashRndDataPool[i] = (uint8_t) rand() % 255;
 		
 	BlInfo blInfo;
-	WyLight::Control testctrl(0,0);
+	Control testctrl(0,0);
 	try
 	{
 		testctrl.BlReadInfo(blInfo);
@@ -324,7 +303,7 @@ size_t ut_WiflyControl_BlFlashRead(void)
 	for(unsigned int i = 0; i < sizeof(g_FlashRndDataPool); i++)
 		g_FlashRndDataPool[i] = (uint8_t) rand() % 255;
 	
-	WyLight::Control testctrl(0,0);
+	Control testctrl(0,0);
 	
 	std::stringstream mStream;
 	
@@ -343,7 +322,6 @@ size_t ut_WiflyControl_BlFlashRead(void)
 
 }
 
-namespace WyLight{
 size_t ut_WiflyControl_BlFlashWrite(void)
 {
 	TestCaseBegin();
@@ -359,7 +337,7 @@ size_t ut_WiflyControl_BlFlashWrite(void)
 		m_FlashRndDataPool[i] = (uint8_t) rand() % 255;
 	}
 	
-	WyLight::Control testctrl(0,0);
+	Control testctrl(0,0);
 	
 	testctrl.BlWriteFlash(0, m_FlashRndDataPool, sizeof(m_FlashRndDataPool));
 	
@@ -369,14 +347,12 @@ size_t ut_WiflyControl_BlFlashWrite(void)
 	}
 	
 	TestCaseEnd();
-	
-}
 }
 
 size_t ut_WiflyControl_BlReadInfo(void)
 {
 	TestCaseBegin();
-	WyLight::Control testctrl(0,0);
+	Control testctrl(0,0);
 	BlInfo mInfo;
 	testctrl.BlReadInfo(mInfo);
 	CHECK(mInfo.familyId == 4);
@@ -417,10 +393,10 @@ size_t ut_WiflyControl_ConfSetDefaults(void)
 	};
 	static const size_t numCommands = sizeof(commands) / sizeof(commands[0]);
 
-	WyLight::Control testee(0, 0);
+	Control testee(0, 0);
 
 	g_TestBuffer.clear();
-	CHECK(ut_WiflyControl_ConfSetDefaults(testee));
+	CHECK(testee.ConfSetDefaults());
 	CHECK(!g_ProxyConnected);
 	CHECK(g_ProxySaved);
 	CHECK(numCommands == g_TestBuffer.size());
@@ -442,24 +418,24 @@ size_t ut_WiflyControl_ConfSetWlan(void)
 	static const std::string phraseToLong(phrase + " ");
 	static const std::string ssid      ("12345678911234567892123456789312");
 	static const std::string ssidToLong(ssid + " ");
-	WyLight::Control testee(0, 0);
+	Control testee(0, 0);
 	
 	// passphrase to short
-	CHECK(!ut_WiflyControl_ConfSetWlan(testee, "", ssid));
+	CHECK(!testee.ConfSetWlan("", ssid));
 	// passphrase to long
-	CHECK(!ut_WiflyControl_ConfSetWlan(testee, phraseToLong, ssid));
+	CHECK(!testee.ConfSetWlan(phraseToLong, ssid));
 
 	// passphrase contains not only alphanumeric characters
-	CHECK(!ut_WiflyControl_ConfSetWlan(testee, phraseContainsNonAlNum, ssid));
+	CHECK(!testee.ConfSetWlan(phraseContainsNonAlNum, ssid));
 
 	// ssid to short
-	CHECK(!ut_WiflyControl_ConfSetWlan(testee, phrase, ""));
+	CHECK(!testee.ConfSetWlan(phrase, ""));
 
 	// ssid to long
-	CHECK(!ut_WiflyControl_ConfSetWlan(testee, phrase, ssidToLong));
+	CHECK(!testee.ConfSetWlan(phrase, ssidToLong));
 
 	// valid passphrase and ssid
-	CHECK(ut_WiflyControl_ConfSetWlan(testee, phrase, ssid));
+	CHECK(testee.ConfSetWlan(phrase, ssid));
 	
 	TestCaseEnd();
 }
@@ -467,7 +443,7 @@ size_t ut_WiflyControl_ConfSetWlan(void)
 size_t ut_WiflyControl_FwSetColorDirectRedOnly(void)
 {
 	TestCaseBegin();
-	WyLight::Control testee(0, 0);
+	Control testee(0, 0);
 	
 	// three leds only, first red, second green last blue
 	uint8_t shortBuffer[1]{0xff};
@@ -485,7 +461,7 @@ size_t ut_WiflyControl_FwSetColorDirectRedOnly(void)
 size_t ut_WiflyControl_FwSetColorDirectThreeLeds(void)
 {
 	TestCaseBegin();
-	WyLight::Control testee(0, 0);
+	Control testee(0, 0);
 	
 	// three leds only, first red, second green last blue
 	uint8_t shortBuffer[3 * 3];
@@ -507,7 +483,7 @@ size_t ut_WiflyControl_FwSetColorDirectThreeLeds(void)
 size_t ut_WiflyControl_FwSetColorDirectToMany(void)
 {
 	TestCaseBegin();
-	WyLight::Control testee(0, 0);
+	Control testee(0, 0);
 	
 	// three leds only, first red, second green last blue
 	uint8_t shortBuffer[2*NUM_OF_LED * 3];
@@ -538,7 +514,7 @@ size_t ut_WiflyControl_FwSetFade_1(void)
 	expectedOutgoingFrame.data.set_fade.fadeTmms = htons(0x0001);
 
 	TestCaseBegin();
-	WyLight::Control testee(0, 0);
+	Control testee(0, 0);
 	
 	// set color
 	testee.FwSetFade("ff00ff");
@@ -566,7 +542,7 @@ size_t ut_WiflyControl_FwSetFade_2(void)
 	expectedOutgoingFrame.data.set_fade.fadeTmms = htons(1000);
 	
 	TestCaseBegin();
-	WyLight::Control testee(0, 0);
+	Control testee(0, 0);
 	
 	// set color
 	testee.FwSetFade("112233", 1000, "11223344", true);
@@ -593,7 +569,7 @@ size_t ut_WiflyControl_FwSetGradient(void)
 	expectedOutgoingFrame.data.set_gradient.fadeTmms = htons(1000);
 	
 	TestCaseBegin();
-	WyLight::Control testee(0, 0);
+	Control testee(0, 0);
 	
 	testee.FwSetGradient("112233","332211", 1000, true, 10, 127);
 	TraceBuffer(ZONE_INFO, &g_SendFrame, sizeof(cmd_set_gradient) + 1, "%02x ", "IS  :");
@@ -611,7 +587,7 @@ size_t ut_WiflyControl_FwSetWait(void)
 	expectedOutgoingFrame.data.wait.waitTmms = htons(1000);
 	
 	TestCaseBegin();
-	WyLight::Control testee(0, 0);
+	Control testee(0, 0);
 	
 	testee.FwSetWait(1000);
 	TraceBuffer(ZONE_INFO, &g_SendFrame, sizeof(cmd_wait) + 1, "%02x ", "IS  :");
@@ -640,7 +616,7 @@ size_t ut_WiflyControl_FwSetRtc(void)
 
 	
 	TestCaseBegin();
-	WyLight::Control testee(0, 0);
+	Control testee(0, 0);
 	
 	testee.FwSetRtc(timeinfo);
 	TraceBuffer(ZONE_INFO, &g_SendFrame, sizeof(rtc_time)+1, "%02x ", "IS  :");
@@ -656,7 +632,7 @@ size_t ut_WiflyControl_FwClearScript(void)
 	expectedOutgoingFrame.cmd = CLEAR_SCRIPT;
 	
 	TestCaseBegin();
-	WyLight::Control testee(0, 0);
+	Control testee(0, 0);
 	
 	testee.FwClearScript();
 	TraceBuffer(ZONE_INFO, &g_SendFrame, 1, "%02x ", "IS  :");
@@ -672,7 +648,7 @@ size_t ut_WiflyControl_FwGetTracebuffer(void)
 	expectedOutgoingFrame.cmd = GET_TRACE;
 	
 	TestCaseBegin();
-	WyLight::Control testee(0, 0);
+	Control testee(0, 0);
 	
 	try {
 		testee.FwGetTracebuffer();
@@ -692,7 +668,7 @@ size_t ut_WiflyControl_FwGetCycletime(void)
 	expectedOutgoingFrame.cmd = GET_CYCLETIME;
 	
 	TestCaseBegin();
-	WyLight::Control testee(0, 0);
+	Control testee(0, 0);
 	
 	try {
 		testee.FwGetCycletime();
@@ -713,7 +689,7 @@ size_t ut_WiflyControl_FwGetRtc(void)
 	expectedOutgoingFrame.cmd = GET_RTC;
 	
 	TestCaseBegin();
-	WyLight::Control testee(0, 0);
+	Control testee(0, 0);
 	
 	try {
 		testee.FwGetRtc(timeinfo);
@@ -732,7 +708,7 @@ size_t ut_WiflyControl_FwGetVersion(void)
 	expectedOutgoingFrame.cmd = GET_FW_VERSION;
 	
 	TestCaseBegin();
-	WyLight::Control testee(0, 0);
+	Control testee(0, 0);
 	
 	try {
 		testee.FwGetVersion();
@@ -755,7 +731,7 @@ size_t ut_WiflyControl_FwLoopOff(void)
 	expectedOutgoingFrame.data.loopEnd.startIndex = 0;
 	
 	TestCaseBegin();
-	WyLight::Control testee(0, 0);
+	Control testee(0, 0);
 	
 	testee.FwLoopOff(100);
 	
@@ -772,7 +748,7 @@ size_t ut_WiflyControl_FwLoopOn(void)
 	expectedOutgoingFrame.cmd = LOOP_ON;
 	
 	TestCaseBegin();
-	WyLight::Control testee(0, 0);
+	Control testee(0, 0);
 	
 	testee.FwLoopOn();
 	
@@ -782,8 +758,9 @@ size_t ut_WiflyControl_FwLoopOn(void)
 	
 	TestCaseEnd();
 }
+} /* namespace WyLight */
 
-
+using namespace WyLight;
 
 int main (int argc, const char* argv[])
 {
@@ -793,9 +770,9 @@ int main (int argc, const char* argv[])
 	RunTest(true, ut_WiflyControl_BlReadInfo);
 	RunTest(true, ut_WiflyControl_BlEraseFlash);
 	RunTest(true, ut_WiflyControl_BlFlashRead);
-	RunTest(true, WyLight::ut_WiflyControl_BlFlashWrite);
+	RunTest(true, ut_WiflyControl_BlFlashWrite);
 	RunTest(true, ut_WiflyControl_BlEepromRead);
-	RunTest(true, WyLight::ut_WiflyControl_BlEepromWrite);
+	RunTest(true, ut_WiflyControl_BlEepromWrite);
 	RunTest(true, ut_WiflyControl_BlEraseEeprom);
 	RunTest(true, ut_WiflyControl_FwSetColorDirectRedOnly);
 	RunTest(true, ut_WiflyControl_FwSetColorDirectThreeLeds);

--- a/library/WiflyControl_ut.cpp
+++ b/library/WiflyControl_ut.cpp
@@ -31,27 +31,20 @@ static const uint32_t g_DebugZones = ZONE_ERROR | ZONE_WARNING | ZONE_INFO | ZON
 uint8_t g_FlashRndDataPool[FLASH_SIZE];
 uint8_t g_EepromRndDataPool[EEPROM_SIZE];
 // empty wrappers to satisfy the linker
-ClientSocket::ClientSocket(uint32_t, uint16_t, int) throw (FatalError) : mSock(0) {}
+ClientSocket::ClientSocket(uint32_t addr, uint16_t port, int style) throw (FatalError) : mSock(0), mSockAddr(addr, port) {}
 ClientSocket::~ClientSocket(void) {}
 TcpSocket::TcpSocket(uint32_t addr, uint16_t port) throw (ConnectionLost, FatalError) : ClientSocket(addr, port, 0) {}
 size_t TcpSocket::Recv(uint8_t* pBuffer, size_t length, timeval* timeout) const throw (FatalError) { return 0;}
 size_t TcpSocket::Send(const uint8_t* frame, size_t length) const {return 0; }
 ComProxy::ComProxy(const TcpSocket& sock) : mSock (sock) {}
 
-#define return_resp {\
-	for(unsigned int i = 0; i < sizeof(resp); i++)\
-	{ \
-		if(responseSize >= i) *pResponse++ = resp[i]; \
-	}\
-	return sizeof(resp);}
-
-
 size_t ComProxy::Send(const BlRequest& req, uint8_t* pResponse, size_t responseSize, bool doSync) const throw(ConnectionTimeout, FatalError)
 {
 	if(typeid(req) == typeid(BlInfoRequest))
 	{
-		uint8_t resp[] = {0x00, 0x03, 0x01, 0x05, 0xff, 0x84, 0x00, 0xfd, 0x00, 0x00};
-		return_resp;
+		static const uint8_t resp[] = {0x00, 0x03, 0x01, 0x05, 0xff, 0x84, 0x00, 0xfd, 0x00, 0x00};
+		memcpy(pResponse, resp, sizeof(resp));
+		return sizeof(resp);
 	}
 	if(typeid(req) == typeid(BlFlashEraseRequest))
 	{
@@ -67,8 +60,8 @@ size_t ComProxy::Send(const BlRequest& req, uint8_t* pResponse, size_t responseS
 			g_FlashRndDataPool[i] = 0x00;
 		}
 		
-		uint8_t resp[] = {0x03};
-		return_resp;
+		*pResponse = 0x03;
+		return 1;
 	}
 	if(typeid(req) == typeid(BlFlashWriteRequest))
 	{
@@ -80,8 +73,8 @@ size_t ComProxy::Send(const BlRequest& req, uint8_t* pResponse, size_t responseS
 			g_FlashRndDataPool[address] = mReq.payload[i];
 		}
 		
-		uint8_t resp[] = {0x04};
-		return_resp;
+		*pResponse = 0x04;
+		return 1;
 	}
 	if(typeid(req) == typeid(BlFlashReadRequest))
 	{
@@ -122,8 +115,8 @@ size_t ComProxy::Send(const BlRequest& req, uint8_t* pResponse, size_t responseS
 			g_EepromRndDataPool[address] = mReq.payload[i];
 		}
 		
-		uint8_t resp[] = {0x06};
-		return_resp;
+		*pResponse = 0x06;
+		return 1;
 		
 	}
 	throw FatalError("Unknown request");


### PR DESCRIPTION
- rebased namespace  changes
- BroadcastReceiver is now able to save its list of known connections to a file and reread it
- added mScore to Endpoint, to support a favourites score in the future (right now 1 is used as favourites threshold to save recent endpoints on BroadcastReceiver shutdown)
